### PR TITLE
Replace fmt.Println/log.Printf with zap logger

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,7 +17,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/msvens/mphotos/internal/server"
@@ -41,7 +40,7 @@ var rootCmd = &cobra.Command{
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }
@@ -69,7 +68,7 @@ func initConfig() {
 		// Find home directory.
 		home, err := os.UserHomeDir()
 		if err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 
@@ -82,6 +81,6 @@ func initConfig() {
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
-		log.Printf("Using config file: %s", viper.ConfigFileUsed())
+		fmt.Println("Using config file:", viper.ConfigFileUsed())
 	}
 }

--- a/internal/dao/img.go
+++ b/internal/dao/img.go
@@ -1,7 +1,6 @@
 package dao
 
 import (
-	"fmt"
 	"github.com/msvens/mimage/img"
 	"github.com/msvens/mphotos/internal/config"
 	"os"
@@ -50,7 +49,7 @@ func cleanImgDir(keep map[string]bool, pt config.PhotoType) error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("Cleaning: %s\n", config.PhotoPath(pt))
+	logger.Infow("Cleaning", "path", config.PhotoPath(pt))
 	numDeleted := 0
 	for _, f := range files {
 		if !keep[f.Name()] {
@@ -62,7 +61,7 @@ func cleanImgDir(keep map[string]bool, pt config.PhotoType) error {
 			numDeleted++
 		}
 	}
-	fmt.Printf("Deleted %v files from %v\n", numDeleted, config.PhotoPath(pt))
+	logger.Infow("Deleted files", "count", numDeleted, "path", config.PhotoPath(pt))
 	return nil
 }
 
@@ -78,7 +77,7 @@ func CleanImageDirs(db *PGDB) error {
 	for k := range config.PhotoPaths() {
 		err := cleanImgDir(fNames, k)
 		if err != nil {
-			fmt.Println("Error cleaning imgDir: ", err)
+			logger.Errorw("Error cleaning imgDir", "error", err)
 		}
 	}
 	return nil

--- a/internal/dao/migrate.go
+++ b/internal/dao/migrate.go
@@ -7,7 +7,7 @@ import (
 // for now this is just hard coded
 func canUpgradeDb(pgdb *PGDB) bool {
 	if v, err := pgdb.Version.Get(); err != nil {
-		fmt.Println("could not get Version info: ", err)
+		logger.Errorw("could not get Version info", "error", err)
 		return false
 	} else {
 		return v.VersionId+1 == DbVersion
@@ -26,7 +26,7 @@ func UpgradeDb() error {
 		if isCurrent, err := pgdb.Version.IsCurrent(); err != nil {
 			return err
 		} else if isCurrent {
-			fmt.Println("Database is up to date")
+			logger.Info("Database is up to date")
 			return nil
 		} else if canUpgradeDb(pgdb) {
 			return upgradeToV3(pgdb)
@@ -36,7 +36,7 @@ func UpgradeDb() error {
 	} else if hasPhotos {
 		return fmt.Errorf("cannot upgrade database")
 	} else {
-		fmt.Println("No database exists. Creating a fresh db")
+		logger.Info("No database exists. Creating a fresh db")
 		if err = pgdb.CreateTables(); err != nil {
 			return err
 		}
@@ -45,7 +45,7 @@ func UpgradeDb() error {
 }
 
 func upgradeToV3(pgdb *PGDB) error {
-	fmt.Println("Upgrading Db to Version: ", DbVersion)
+	logger.Infow("Upgrading Db to Version", "version", DbVersion)
 
 	var err error
 	var v *Version
@@ -56,18 +56,18 @@ func upgradeToV3(pgdb *PGDB) error {
 		return err
 	}
 
-	fmt.Println("Db Updated. Change Version Info")
+	logger.Info("Db Updated. Change Version Info")
 	if v, err = pgdb.Version.Update(); err != nil {
 		return err
 	} else {
-		fmt.Println("Updated Db to version: ", v.VersionId)
+		logger.Infow("Updated Db to version", "version", v.VersionId)
 	}
-	fmt.Println("create photo stream album")
+	logger.Info("create photo stream album")
 	if a, err = pgdb.Album.Add("photostream", "Default public photostream", ""); err != nil {
 		return err
 	}
 
-	fmt.Println("Add all public photos to it")
+	logger.Info("Add all public photos to it")
 
 	if err = pgdb.db.Select(&photos, "SELECT * FROM img WHERE private = false"); err != nil {
 		return err
@@ -81,7 +81,7 @@ func upgradeToV3(pgdb *PGDB) error {
 	}
 
 	//finally delete the private column
-	fmt.Println("Drop the private column from image")
+	logger.Info("Drop the private column from image")
 	_, err = pgdb.db.Exec("ALTER TABLE img DROP COLUMN private")
 	return err
 }

--- a/internal/gmail/gmail.go
+++ b/internal/gmail/gmail.go
@@ -3,7 +3,8 @@ package gmail
 import (
 	"context"
 	"encoding/base64"
-	"fmt"
+
+	"go.uber.org/zap"
 	"golang.org/x/oauth2"
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
@@ -13,6 +14,13 @@ const (
 	MIME_TXT  = "MIME-version: 1.0;\nContent-Type: text/plain; charset=\"UTF-8\";\n\n"
 	MIME_HTML = "MIME-version: 1.0;\nContent-Type: text/html; charset=\"UTF-8\";\n\n"
 )
+
+var logger *zap.SugaredLogger
+
+func init() {
+	l, _ := zap.NewDevelopment()
+	logger = l.Sugar()
+}
 
 type GmailService struct {
 	service *gmail.Service
@@ -50,7 +58,7 @@ func (gs *GmailService) SendTextMessage(to string, subject string, body string) 
 	message.Raw = base64.URLEncoding.EncodeToString(msg)
 	_, err := gs.service.Users.Messages.Send("me", &message).Do()
 	if err != nil {
-		fmt.Println("error sending email")
+		logger.Errorw("error sending email", "error", err)
 		return false, err
 	}
 	return true, nil
@@ -67,7 +75,7 @@ func (gs *GmailService) SendHtmlMessage(to string, subject string, body string) 
 	message.Raw = base64.URLEncoding.EncodeToString(msg)
 	_, err := gs.service.Users.Messages.Send("me", &message).Do()
 	if err != nil {
-		fmt.Println("error sending email")
+		logger.Errorw("error sending email", "error", err)
 		return false, err
 	}
 	return true, nil

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -181,7 +181,7 @@ func (s *mserver) handleGoogleLogin(w http.ResponseWriter, r *http.Request) {
 	}
 	//make sure only logged in users can execute this
 	if !ctxLoggedIn(r.Context()) {
-		psResponse(nil, UnauthorizedError("user not logged in"), w)
+		s.psResponse(nil, UnauthorizedError("user not logged in"), w)
 		return
 	}
 	redirUrl, unesc := parseDir()

--- a/internal/server/middelware.go
+++ b/internal/server/middelware.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"github.com/google/uuid"
 	"github.com/gorilla/schema"
+	"go.uber.org/zap"
 	"io"
-	"log"
 	"net/http"
 	"strings"
 )
@@ -83,9 +83,9 @@ func (s *mserver) authOnly(rh reqHandler) http.HandlerFunc {
 		//s.l.Debugw("AuthReq", "uri", r.RequestURI, "method", r.Method)
 		if ctxLoggedIn(r.Context()) {
 			data, err := rh(r)
-			psResponse(data, err, w)
+			s.psResponse(data, err, w)
 		} else {
-			psResponse(nil, UnauthorizedError("user not logged in"), w)
+			s.psResponse(nil, UnauthorizedError("user not logged in"), w)
 		}
 	}
 }
@@ -93,14 +93,14 @@ func (s *mserver) authOnly(rh reqHandler) http.HandlerFunc {
 func (s *mserver) mResponse(handler mHandler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		data, err := handler(w, r)
-		psResponse(data, err, w)
+		s.psResponse(data, err, w)
 	}
 }
 
 func (s *mserver) loginInfo(lh loginHandler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		data, err := lh(r, ctxLoggedIn(r.Context()))
-		psResponse(data, err, w)
+		s.psResponse(data, err, w)
 	}
 }
 
@@ -108,15 +108,15 @@ func (s *mserver) guestOnly(gh guestHandler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var guest = ctxGuest(r.Context())
 		if guest == emptyuuid {
-			psResponse(nil, UnauthorizedError("guest not found"), w)
+			s.psResponse(nil, UnauthorizedError("guest not found"), w)
 		} else {
 			data, err := gh(r, guest)
-			psResponse(data, err, w)
+			s.psResponse(data, err, w)
 		}
 	}
 }
 
-func psResponse(data interface{}, err error, w http.ResponseWriter) {
+func (s *mserver) psResponse(data interface{}, err error, w http.ResponseWriter) {
 	setJson(w)
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
@@ -130,7 +130,7 @@ func psResponse(data interface{}, err error, w http.ResponseWriter) {
 	}
 	e := enc.Encode(resp)
 	if e != nil {
-		log.Printf("could not encode response: %v", e)
+		s.l.Errorw("could not encode response", zap.Error(e))
 	}
 }
 


### PR DESCRIPTION
## Janitor Agent - Replace fmt.Println/log.Printf with zap logger

Several files use stdlib fmt.Println or log.Printf for output instead of the project's established go.uber.org/zap structured logger. This causes inconsistent log formatting and loses structured context (levels, fields, caller info).

### Changes

- internal/gmail/gmail.go: Replace `fmt.Println("error sending email")` in SendTextMessage and SendHtmlMessage with a package-level zap logger error call (e.g. `logger.Errorw("error sending email", "error", err)`). Add a package-level `var logger *zap.SugaredLogger` initialized in an `init()` func, mirroring the pattern in internal/dao/dao.go.
- internal/dao/migrate.go: Replace all `fmt.Println(...)` calls in UpgradeDb and upgradeToV3 with calls on a logger (the package-level `logger *zap.SugaredLogger` already declared in internal/dao/dao.go). For example, `fmt.Println("Database is up to date")` → `logger.Info("Database is up to date")`.
- internal/dao/img.go: Replace `fmt.Printf("Cleaning: %s\n", ...)`, `fmt.Printf("Deleted %v files...")`, and `fmt.Println("Error cleaning imgDir: ", err)` in cleanImgDir and CleanImageDirs with calls on the package-level zap logger already present in the dao package.
- internal/server/middelware.go: Remove the `"log"` import and replace `log.Printf("could not encode response: %v", e)` in psResponse with `s.l.Errorw("could not encode response", zap.Error(e))`. Extract the logger from an `mserver` receiver or pass it — psResponse is a package-level func, so add a logger parameter or use the server's logger; alternatively change psResponse to a method on mserver.
- cmd/root.go: Replace `fmt.Println(err)` in Execute() and initConfig() with `fmt.Fprintln(os.Stderr, err)` at minimum, and replace `log.Printf("Using config file: %s", ...)` with a direct `fmt.Println` or structured log call to remove the inconsistent stdlib `log` usage. Remove the `"log"` import if no longer needed.

---
*Created by [janitor-agent](https://github.com/msvens/janitor-agent)*