### PR TITLE
Fix typos in server error messages and parameter names

### DIFF
--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -31,7 +31,7 @@ func (s *mserver) handleLogin(w http.ResponseWriter, r *http.Request) (interface
 		if e := session.Save(r, w); e != nil {
 			return nil, InternalError(e.Error())
 		}
-		return nil, UnauthorizedError("Incorret user password")
+		return nil, UnauthorizedError("Incorrect user password")
 	}
 	user := &AuthUser{true}
 	session.Values["user"] = user
@@ -117,12 +117,12 @@ func (s *mserver) getToken(r *http.Request) (*oauth2.Token, string, error) {
 	}
 
 	if token, err := s.gconfig.Exchange(context.TODO(), code); err != nil {
-		s.l.Errorw("code exchage error", zap.Error(err))
+		s.l.Errorw("code exchange error", zap.Error(err))
 		return nil, state, UnauthorizedError(err.Error())
 	} else {
 		if u, e := url.QueryUnescape(state); e != nil {
 			s.l.Errorw("could not unescape state", zap.Error(e))
-			return nil, state, BadRequestError("invalid ouath state")
+			return nil, state, BadRequestError("invalid oauth state")
 		} else {
 			return token, u, nil
 		}
@@ -173,7 +173,7 @@ func (s *mserver) handleGoogleLogin(w http.ResponseWriter, r *http.Request) {
 			s.l.Info("could not parse redirection url:  ", err)
 			return root, "/"
 		} else if parsed.IsAbs() {
-			s.l.Info("Absolut url not allowed: ", unesc)
+			s.l.Info("Absolute url not allowed: ", unesc)
 			return root, "/"
 		} else {
 			return redir, unesc

--- a/internal/server/photos.go
+++ b/internal/server/photos.go
@@ -90,7 +90,7 @@ func (s *mserver) handleDownloadPhoto(w http.ResponseWriter, r *http.Request) {
 	http.ServeFile(w, r, config.PhotoFilePath(config.Original, p.FileName))
 }
 
-func (s *mserver) handlePhotoAlbums(r *http.Request, loogedIn bool) (interface{}, error) {
+func (s *mserver) handlePhotoAlbums(r *http.Request, loggedIn bool) (interface{}, error) {
 	id, err := uuid.Parse(Var(r, "photoid"))
 	if err != nil {
 		return nil, BadRequestError("could not parse img id")
@@ -99,7 +99,7 @@ func (s *mserver) handlePhotoAlbums(r *http.Request, loogedIn bool) (interface{}
 	if err != nil {
 		return nil, err
 	}
-	if !loogedIn {
+	if !loggedIn {
 		for i := range albums {
 			albums[i].Code = ""
 		}


### PR DESCRIPTION
## Janitor Agent - Fix typos in server error messages and parameter names

Several string literals and a parameter name in the server package contain clear typos that produce misleading error messages and confusing code: 'Incorret', 'exchage', 'ouath', 'Absolut' in auth.go, and the parameter name 'loogedIn' (instead of 'loggedIn') in photos.go.

### Changes

- internal/server/auth.go: Fix typo in string literal: change 'Incorret user password' to 'Incorrect user password'
- internal/server/auth.go: Fix typo in log message: change 'code exchage error' to 'code exchange error'
- internal/server/auth.go: Fix typo in error message: change 'invalid ouath state' to 'invalid oauth state'
- internal/server/auth.go: Fix typo in log message: change 'Absolut url not allowed' to 'Absolute url not allowed'
- internal/server/photos.go: Fix parameter name typo: rename 'loogedIn' to 'loggedIn' in func signature for handlePhotoAlbums

---
*Created by [janitor-agent](https://github.com/msvens/janitor-agent)*