### PR TITLE
Remove commented-out dead code across server and dao packages

### DIFF
--- a/internal/dao/dao.go
+++ b/internal/dao/dao.go
@@ -7,8 +7,6 @@ import (
 	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/jmoiron/sqlx"
 	"github.com/msvens/mimage/metadata"
-
-	//"github.com/msvens/mexif"
 	"github.com/msvens/mphotos/internal/config"
 	"go.uber.org/zap"
 )
@@ -123,8 +121,6 @@ type PGDB struct {
 
 var logger *zap.SugaredLogger
 
-//var pg *PGDB = nil
-
 func init() {
 	l, _ := zap.NewDevelopment()
 	logger = l.Sugar()
@@ -180,7 +176,6 @@ func (pgd *PGDB) tableExists(table string) bool {
 }
 
 func (pgd *PGDB) CreateTables() error {
-	//pgd.db.MustExec(schemaV1)
 	if _, err := pgd.db.Exec(schemaV3); err != nil {
 		return err
 	} else { //make sure version is correct

--- a/internal/dao/photo.go
+++ b/internal/dao/photo.go
@@ -41,7 +41,6 @@ func (dao *PhotoPG) Albums(id uuid.UUID) ([]*Album, error) {
 		return nil, fmt.Errorf("no such photo")
 	}
 	ret := []*Album{}
-	//TODO: change to a join for consistency
 	stmt := "SELECT * FROM album WHERE id IN (select albumId FROM albumphotos WHERE photoId = $1)"
 	err := dao.db.Select(&ret, stmt, id)
 	return ret, err

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -19,11 +19,7 @@ func (s *mserver) handleLogin(w http.ResponseWriter, r *http.Request) (interface
 	type request struct {
 		Password string `json:"password" schema:"password"`
 	}
-	//session, err := s.store.Get(r, config.SessionCookieName())
 	session, _ := s.store.Get(r, s.cookieName)
-	/*if err != nil {
-		return nil, InternalError(err.Error())
-	}*/
 	var loginParams request
 	if err := decodeRequest(r, &loginParams); err != nil {
 		return nil, err
@@ -93,19 +89,11 @@ func (s *mserver) tokenFromFile(file string) (*oauth2.Token, error) {
 
 func (s *mserver) authFromFile() error {
 	if token, err := s.tokenFromFile(s.tokenFile); err != nil {
-		//s.setDriveService(nil)
 		s.ds = nil
 		s.ms = nil
 		return err
 	} else {
 		return s.setGoogleServices(token)
-		/*if drv, err := gdrive.NewDriveService(token, s.gconfig); err != nil {
-			s.setDriveService(nil)
-			return err
-		} else {
-			s.setDriveService(drv)
-			return nil
-		}*/
 	}
 }
 

--- a/internal/server/drive.go
+++ b/internal/server/drive.go
@@ -293,16 +293,6 @@ func worker(jobChan <-chan *Job) {
 
 func process(job *Job) {
 
-	/*
-		tool, err := mexif.NewMExifTool()
-		defer tool.Close()
-
-		if err != nil {
-			finishJob(job, err)
-			return
-		}
-	*/
-
 	job.State = StateStarted
 
 	for _, f := range job.files {

--- a/internal/server/photos.go
+++ b/internal/server/photos.go
@@ -72,11 +72,6 @@ func (s *mserver) handleDeletePhotos(r *http.Request) (interface{}, error) {
 }
 
 func (s *mserver) handleDownloadPhoto(w http.ResponseWriter, r *http.Request) {
-	/*if loggedIn := ctxLoggedIn(r.Context()); !loggedIn {
-		http.Error(w, "User not logged in", http.StatusUnauthorized)
-		return
-	}*/
-
 	id, err := uuid.Parse(Var(r, "photoid"))
 	if err != nil {
 		http.Error(w, "Could not parse Id", http.StatusBadRequest)

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -6,9 +6,6 @@ func (s *mserver) routes() {
 
 	s.mGET("/albums", s.loginInfo(s.handleAlbums))
 	s.mPUT("/albums", s.authOnly(s.handleAddAlbum))
-	// Removed: conflicts with /albums/{albumid}/... in stdlib ServeMux.
-	// Not used by mphotos-ui. Can be deleted if confirmed unused.
-	// s.mGET("/albums/names/{name}", s.loginInfo(s.handleAlbumByName))
 	s.mGET("/albums/{albumid}", s.loginInfo(s.handleAlbum))
 	s.mDELETE("/albums/{albumid}", s.authOnly(s.handleDeleteAlbum))
 	s.mPUT("/albums/{albumid}", s.authOnly(s.handleUpdateAlbum))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -20,7 +20,6 @@ import (
 )
 
 type mserver struct {
-	//dbold           model.DataStore
 	pg          *dao.PGDB
 	ds          *gdrive.DriveService
 	ms          *gmail.GmailService
@@ -32,13 +31,6 @@ type mserver struct {
 	guestCookie string
 	tokenFile   string
 	gconfig     *oauth2.Config
-	/*imgDir       string
-	cameraDir    string
-	thumbDir     string
-	portraitDir  string
-	landscapeDir string
-	squareDir    string
-	resizeDir    string*/
 }
 
 func newServer(prefixPath string, logger *zap.SugaredLogger) *mserver {
@@ -152,17 +144,10 @@ func StartMServer() {
 
 	close(jobChan)
 	wg.Wait()
-	//if s.ps != nil {
-	//	s.ps.Shutdown()
-	//}
 
 	if err := srv.Shutdown(ctx); err != nil {
 		s.l.Fatalw("server shutdown failed", zap.Error(err))
 	}
-
-	/*if err := s.dbold.CloseDb(); err != nil {
-		s.l.Fatalw("db close failed", zap.Error(err))
-	}*/
 
 	if err := s.pg.Close(); err != nil {
 		s.l.Fatalw("PGDB close failed", zap.Error(err))


### PR DESCRIPTION
## Janitor Agent - Remove commented-out dead code across server and dao packages

Large blocks of commented-out code (old struct fields, replaced implementations, removed routes, and debug scaffolding) litter multiple files, reducing readability. These are clearly superseded by current implementations and carry no documentation value.

### Changes

- internal/server/server.go: Remove the commented-out old struct fields (imgDir, cameraDir, thumbDir, portraitDir, landscapeDir, squareDir, resizeDir) inside the mserver struct definition.
- internal/server/server.go: Remove the commented-out shutdown block (`//if s.ps != nil { s.ps.Shutdown() }`) and the commented-out dbold.CloseDb block.
- internal/server/auth.go: Remove the commented-out session error handling block inside handleLogin (the `/*if err != nil { ... }*/` section).
- internal/server/auth.go: Remove the commented-out alternative drive service initialization block inside authFromFile.
- internal/server/photos.go: Remove the commented-out login guard block at the top of handleDownloadPhoto.
- internal/server/routes.go: Remove the large comment block referencing the removed /albums/names/{name} route.
- internal/server/drive.go: Remove the commented-out mexif tool initialization block inside the process() function.
- internal/dao/dao.go: Remove the commented-out import `// "github.com/msvens/mexif"`.
- internal/dao/dao.go: Remove the commented-out `//var pg *PGDB = nil` variable declaration.
- internal/dao/dao.go: Remove commented-out `//pgd.db.MustExec(schemaV1)` line inside CreateTables.
- internal/dao/photo.go: Remove commented-out `//TODO: change to a join for consistency` comment in Albums() if it is not being actioned.

---
*Created by [janitor-agent](https://github.com/msvens/janitor-agent)*