### PR TITLE
Add missing return after http.Error in handleEditPreviewImage

### DIFF
--- a/internal/server/img.go
+++ b/internal/server/img.go
@@ -98,6 +98,7 @@ func (s *mserver) handleEditPreviewImage(w http.ResponseWriter, r *http.Request)
 	srcImage, err := img.Open(fname)
 	if err != nil {
 		http.Error(w, "could not open image file", http.StatusInternalServerError)
+		return
 	}
 	if par.Rotation != 0 {
 		srcImage = img.RotateImage(srcImage, par.Rotation)


### PR DESCRIPTION
## Janitor Agent - Add missing return after http.Error in handleEditPreviewImage

In `handleEditPreviewImage` in img.go, the call `http.Error(w, "could not open image file", http.StatusInternalServerError)` is not followed by a `return` statement. Execution continues to the crop/encode logic operating on a nil `srcImage`, causing a nil-pointer panic for any request where the image file cannot be opened.

### Changes

- internal/server/img.go: After `http.Error(w, "could not open image file", http.StatusInternalServerError)`, add a `return` statement so the function exits immediately instead of falling through to `img.RotateImage(srcImage, par.Rotation)` with a nil srcImage.

---
*Created by [janitor-agent](https://github.com/msvens/janitor-agent)*