### PR TITLE
Add configurable admin login: password or Google OAuth

### DIFF
--- a/config_example.yaml
+++ b/config_example.yaml
@@ -8,7 +8,15 @@ service:
   root: .server #default
   imgDir: img #img path
   thumbDir: thumb #thumbnail path
-  password: password
+
+auth:
+  method: password           # "password" or "google"
+  password: password         # used when method=password
+  google:
+    allowedEmails:
+      - msvens@gmail.com
+    loginRedirectUrl: http://localhost:8050/api/auth/login/callback
+    uiRedirectPath: /        # where to send the browser after login (success or failure with ?error=)
 
 session:
   authKey: authKey #64 bytes recommended

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -178,8 +178,32 @@ func CameraFilePath(fname string) string {
 	return filepath.Join(CameraPath(), fname)
 }
 
-func ServicePassword() string {
-	return viper.GetString("service.password")
+func AuthMethod() string {
+	m := viper.GetString("auth.method")
+	if m == "" {
+		return "password"
+	}
+	return m
+}
+
+func AuthPassword() string {
+	return viper.GetString("auth.password")
+}
+
+func AuthAllowedEmails() []string {
+	return viper.GetStringSlice("auth.google.allowedEmails")
+}
+
+func AuthGoogleLoginRedirectUrl() string {
+	return viper.GetString("auth.google.loginRedirectUrl")
+}
+
+func AuthGoogleUIRedirectPath() string {
+	p := viper.GetString("auth.google.uiRedirectPath")
+	if p == "" {
+		return "/"
+	}
+	return p
 }
 
 func SessionAuthcKey() string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -66,8 +66,19 @@ func TestConfigFile(t *testing.T) {
 	if ServiceRoot() != ".server" {
 		t.Errorf("expected .server got %v", ServiceRoot())
 	}
-	if ServicePassword() != "password" {
-		t.Errorf("expected password got %v", ServicePassword())
+	//auth config:
+	if AuthMethod() != "password" {
+		t.Errorf("expected password got %v", AuthMethod())
+	}
+	if AuthPassword() != "password" {
+		t.Errorf("expected password got %v", AuthPassword())
+	}
+	allowed := AuthAllowedEmails()
+	if len(allowed) != 1 || allowed[0] != "msvens@gmail.com" {
+		t.Errorf("expected [msvens@gmail.com] got %v", allowed)
+	}
+	if AuthGoogleLoginRedirectUrl() != "http://localhost:8050/api/auth/login/callback" {
+		t.Errorf("unexpected login redirect url: %v", AuthGoogleLoginRedirectUrl())
 	}
 	//google config:
 	if GoogleClientId() != "clientId" {

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -2,32 +2,37 @@ package server
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"github.com/msvens/mphotos/internal/config"
 	"go.uber.org/zap"
 	"golang.org/x/oauth2"
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 )
+
+const oauthLoginStateMaxAge = 600 // 10 minutes
 
 type AuthUser struct {
 	Authenticated bool `json:"authenticated"`
 }
 
 func (s *mserver) handleLogin(w http.ResponseWriter, r *http.Request) (interface{}, error) {
+	if config.AuthMethod() != "password" {
+		return nil, newError(http.StatusMethodNotAllowed, "password login disabled; use /api/login/google")
+	}
 	type request struct {
 		Password string `json:"password" schema:"password"`
 	}
-	//session, err := s.store.Get(r, config.SessionCookieName())
 	session, _ := s.store.Get(r, s.cookieName)
-	/*if err != nil {
-		return nil, InternalError(err.Error())
-	}*/
 	var loginParams request
 	if err := decodeRequest(r, &loginParams); err != nil {
 		return nil, err
-	} else if loginParams.Password != config.ServicePassword() {
+	} else if loginParams.Password != config.AuthPassword() {
 		if e := session.Save(r, w); e != nil {
 			return nil, InternalError(e.Error())
 		}
@@ -40,6 +45,10 @@ func (s *mserver) handleLogin(w http.ResponseWriter, r *http.Request) (interface
 		return nil, InternalError(err.Error())
 	}
 	return user, nil
+}
+
+func (s *mserver) handleAuthMethod(w http.ResponseWriter, r *http.Request) (interface{}, error) {
+	return map[string]string{"method": config.AuthMethod()}, nil
 }
 
 func (s *mserver) handleLogout(w http.ResponseWriter, r *http.Request) (interface{}, error) {
@@ -210,4 +219,142 @@ func (s *mserver) isGoogleConnected() bool {
 		return false
 	}
 	return true
+}
+
+// Google login flow (separate from the Drive OAuth flow). Uses gconfigLogin
+// which only requests openid/email/profile scopes, and verifies the returned
+// email against config.AuthAllowedEmails before issuing the session cookie.
+
+func (s *mserver) loginStateCookieName() string {
+	return s.cookieName + "-login-state"
+}
+
+func (s *mserver) handleGoogleLoginRedirect(w http.ResponseWriter, r *http.Request) {
+	state, err := generateOAuthState()
+	if err != nil {
+		s.l.Errorw("could not generate oauth state", zap.Error(err))
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	stateSession, _ := s.store.Get(r, s.loginStateCookieName())
+	stateSession.Values["state"] = state
+	stateSession.Options.MaxAge = oauthLoginStateMaxAge
+	if err := stateSession.Save(r, w); err != nil {
+		s.l.Errorw("could not save oauth state cookie", zap.Error(err))
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	http.Redirect(w, r, s.gconfigLogin.AuthCodeURL(state), http.StatusTemporaryRedirect)
+}
+
+func (s *mserver) handleGoogleLoginCallback(w http.ResponseWriter, r *http.Request) {
+	redirTo := func(errCode string) {
+		target := config.AuthGoogleUIRedirectPath()
+		if errCode != "" {
+			sep := "?"
+			if strings.Contains(target, "?") {
+				sep = "&"
+			}
+			target = target + sep + "error=" + url.QueryEscape(errCode)
+		}
+		http.Redirect(w, r, target, http.StatusTemporaryRedirect)
+	}
+
+	queryState := r.FormValue("state")
+	stateSession, _ := s.store.Get(r, s.loginStateCookieName())
+	expected, _ := stateSession.Values["state"].(string)
+	// Always expire the state cookie after first use, regardless of outcome.
+	stateSession.Options.MaxAge = -1
+	_ = stateSession.Save(r, w)
+
+	if queryState == "" || expected == "" || queryState != expected {
+		s.l.Info("oauth login state mismatch")
+		redirTo("invalid_state")
+		return
+	}
+
+	code := r.FormValue("code")
+	if code == "" {
+		redirTo("invalid_state")
+		return
+	}
+
+	token, err := s.gconfigLogin.Exchange(r.Context(), code)
+	if err != nil {
+		s.l.Errorw("login code exchange failed", zap.Error(err))
+		redirTo("exchange_failed")
+		return
+	}
+
+	email, verified, err := fetchGoogleUserinfo(r.Context(), token)
+	if err != nil {
+		s.l.Errorw("userinfo fetch failed", zap.Error(err))
+		redirTo("exchange_failed")
+		return
+	}
+	if !verified {
+		s.l.Infow("google email not verified", "email", email)
+		redirTo("unauthorized_email")
+		return
+	}
+	if !emailAllowed(email, config.AuthAllowedEmails()) {
+		s.l.Infow("email not in allowlist", "email", email)
+		redirTo("unauthorized_email")
+		return
+	}
+
+	session, _ := s.store.Get(r, s.cookieName)
+	session.Values["user"] = &AuthUser{true}
+	session.Options.MaxAge = Session_Month
+	if err := session.Save(r, w); err != nil {
+		s.l.Errorw("could not save login session", zap.Error(err))
+		redirTo("exchange_failed")
+		return
+	}
+	redirTo("")
+}
+
+func generateOAuthState() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.URLEncoding.EncodeToString(b), nil
+}
+
+func fetchGoogleUserinfo(ctx context.Context, token *oauth2.Token) (string, bool, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", "https://www.googleapis.com/oauth2/v3/userinfo", nil)
+	if err != nil {
+		return "", false, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token.AccessToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", false, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return "", false, fmt.Errorf("userinfo: status %d", resp.StatusCode)
+	}
+	var info struct {
+		Email         string `json:"email"`
+		EmailVerified bool   `json:"email_verified"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		return "", false, err
+	}
+	return info.Email, info.EmailVerified, nil
+}
+
+func emailAllowed(email string, allowlist []string) bool {
+	if email == "" {
+		return false
+	}
+	e := strings.ToLower(email)
+	for _, a := range allowlist {
+		if strings.ToLower(a) == e {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -20,6 +20,8 @@ func (s *mserver) routes() {
 	s.mPUT("/albums/{albumid}/photos/set", s.authOnly(s.handleSetAlbumPhotos))
 
 	s.r.HandleFunc(s.prefixPath+"/auth/callback", s.handleGoogleCallback)
+	s.r.HandleFunc(s.prefixPath+"/auth/login/callback", s.handleGoogleLoginCallback)
+	s.mGET("/auth/method", s.mResponse(s.handleAuthMethod))
 
 	s.mGET("/cameras", s.mResponse(s.handleCameras))
 	s.mGET("/cameras/{cameraid}", s.mResponse(s.handleCamera))
@@ -33,7 +35,7 @@ func (s *mserver) routes() {
 	s.mGET("/drive", s.authOnly(s.handleDrive))
 	s.mGET("/drive/authenticated", s.authOnly(s.handleAuthenticatedDrive))
 	s.mGET("/drive/disconnect", s.authOnly(s.handleDisconnectDrive))
-	s.mGET("/drive/auth", s.handleGoogleLogin)
+
 	s.mGET("/drive/check", s.authOnly(s.handleCheckDrive))
 	s.mPUT("/drive/upload", s.authOnly(s.handleAddDrivePhotos))
 	s.mPUT("/drive/job/schedule", s.authOnly(s.handleScheduleDriveJob))
@@ -50,6 +52,7 @@ func (s *mserver) routes() {
 	s.mGET("/resizes/{name}", s.handleResize)
 
 	s.mPUT("/login", s.mResponse(s.handleLogin))
+	s.mGET("/login/google", s.handleGoogleLoginRedirect)
 	s.mGET("/logout", s.mResponse(s.handleLogout))
 	s.mGET("/loggedin", s.loginInfo(s.handleLoggedIn))
 

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -32,7 +32,7 @@ func (s *mserver) routes() {
 	s.mGET("/drive", s.authOnly(s.handleDrive))
 	s.mGET("/drive/authenticated", s.authOnly(s.handleAuthenticatedDrive))
 	s.mGET("/drive/disconnect", s.authOnly(s.handleDisconnectDrive))
-
+	s.mGET("/drive/auth", s.handleGoogleLogin)
 	s.mGET("/drive/check", s.authOnly(s.handleCheckDrive))
 	s.mPUT("/drive/upload", s.authOnly(s.handleAddDrivePhotos))
 	s.mPUT("/drive/job/schedule", s.authOnly(s.handleScheduleDriveJob))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -20,15 +20,15 @@ import (
 )
 
 type mserver struct {
-	pg          *dao.PGDB
-	ds          *gdrive.DriveService
-	ms          *gmail.GmailService
-	r           *http.ServeMux
-	l           *zap.SugaredLogger
-	prefixPath  string
-	store       *sessions.CookieStore
-	cookieName  string
-	guestCookie string
+	pg           *dao.PGDB
+	ds           *gdrive.DriveService
+	ms           *gmail.GmailService
+	r            *http.ServeMux
+	l            *zap.SugaredLogger
+	prefixPath   string
+	store        *sessions.CookieStore
+	cookieName   string
+	guestCookie  string
 	tokenFile    string
 	gconfig      *oauth2.Config
 	gconfigLogin *oauth2.Config

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -30,8 +30,9 @@ type mserver struct {
 	store       *sessions.CookieStore
 	cookieName  string
 	guestCookie string
-	tokenFile   string
-	gconfig     *oauth2.Config
+	tokenFile    string
+	gconfig      *oauth2.Config
+	gconfigLogin *oauth2.Config
 	/*imgDir       string
 	cameraDir    string
 	thumbDir     string
@@ -93,6 +94,14 @@ func newServer(prefixPath string, logger *zap.SugaredLogger) *mserver {
 		Endpoint:     google.Endpoint,
 		RedirectURL:  config.GoogleRedirectUrl(),
 		Scopes:       []string{"https://www.googleapis.com/auth/userinfo.email", gdrive.ReadOnlyScope(), gmail.ComposeScope()},
+	}
+
+	s.gconfigLogin = &oauth2.Config{
+		ClientID:     config.GoogleClientId(),
+		ClientSecret: config.GoogleClientSecret(),
+		Endpoint:     google.Endpoint,
+		RedirectURL:  config.AuthGoogleLoginRedirectUrl(),
+		Scopes:       []string{"openid", "email", "profile"},
 	}
 
 	return &s


### PR DESCRIPTION
## Summary

- Adds a server-side `auth.method` switch to choose between the existing username/password admin login and a new Sign in with Google flow gated by an email allowlist
- Google login uses a second `oauth2.Config` with `openid email profile` scopes and its own callback URL — completely separate from the existing Drive OAuth flow, sharing only the Google Cloud client credentials
- Existing session cookie and `authOnly` middleware are unchanged; both methods end up setting the same `AuthUser{Authenticated: true}` cookie, so all downstream auth behaves identically

## New endpoints

| Method | Path | Notes |
|---|---|---|
| GET | `/api/auth/method` | Tells the UI which method is configured |
| GET | `/api/login/google` | Browser navigation target to start Google login |
| GET | `/api/auth/login/callback` | Google's callback — validates state, exchanges code, checks email allowlist, sets the cookie |

## Config

A new top-level `auth` block replaces `service.password`:

```yaml
auth:
  method: password           # "password" or "google"
  password: password
  google:
    allowedEmails:
      - someone@example.com
    loginRedirectUrl: https://example.com/api/auth/login/callback
    uiRedirectPath: /
```

`config_example.yaml` updated; `ServicePassword()` removed in favor of `AuthPassword()`.

## Out of scope (tracked as follow-ups)

- Bcrypt for the password path (still plain-text compared)
- Real CSRF state on the **existing** Drive OAuth flow (the new login flow does it properly)
- Renaming the existing Drive handlers/routes — `handleGoogleLogin` actually starts the Drive flow, not a login flow, which is now confusing

## Test plan

- [x] `curl /api/auth/method` returns the configured method
- [x] Google login: browser → consent → callback → cookie set → land on `/account`
- [x] Logout, then login again — works without re-consent
- [x] CSRF state cookie validated end-to-end (state survives Google round-trip)
- [x] Subsequent admin endpoints (`/api/loggedin`, `/api/user`, `/api/user/config`) all report `loggedIn: true` after Google login
- [ ] Negative path: email not in allowlist → redirects with `?error=unauthorized_email`
- [ ] Negative path: tampered state → redirects with `?error=invalid_state`
- [ ] Password method still works when `auth.method: password`

UI changes live in `mphotos-ui` (see `CLAUDE_LOGIN_HANDOFF.md` in that repo).