### PR TITLE
Promote photostream id and make /api/photos public

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,165 @@
+# Migration Guide — Database v4 / Public Photo Stream
+
+This release promotes the **photo stream album id** from the client-owned config
+blob to a typed server column, and makes `GET /api/photos` a public endpoint that
+serves the photostream to guests and the full library to the owner. It also adds
+paging and ordering to that endpoint.
+
+It has two audiences:
+
+- **Deploying the server** → [Server / deployment](#server--deployment). There is a
+  required database migration; the server does **not** run it for you.
+- **Updating a UI app** (`mphotos-ui`, `mphotos-svelte`) → [UI apps](#ui-apps).
+
+> **Nothing breaks immediately.** The currently deployed UI keeps working against
+> the migrated backend without any change (see [Backward compatibility](#backward-compatibility)).
+> The UI changes below are how you *adopt* the new server-side behavior; they are
+> not required just to keep the site running.
+
+---
+
+## Server / deployment
+
+`DbVersion` goes from **3 → 4**. The migration adds one column
+(`usert.photostreamalbumid`) and seeds it once from the existing config blob.
+
+The running server neither auto-migrates nor version-gates on startup, and the new
+binary's user queries select the new column — so a **new binary against an
+un-migrated (v3) database will error on every user query**. Run the migration
+before serving traffic.
+
+### Steps
+
+```sh
+# 1. (recommended) back up first — any schema change deserves a dump
+pg_dump ... > mphotos-pre-v4.sql
+
+# 2. deploy the new (v4) binary, but do not start serving yet
+
+# 3. run the migration with the NEW binary
+./mphotos db upgrade      # v3 → v4: adds usert.photostreamalbumid, seeds from config
+
+# 4. confirm
+./mphotos db version      # should report 4
+
+# 5. (re)start the service
+```
+
+Notes:
+
+- The upgrade is guarded to a single step (v3 → v4 only) and is a single `ALTER
+  TABLE` plus one `UPDATE`. It is fast.
+- If the old config blob has no `photoStreamAlbumId`, the column is simply left
+  empty — the migration does not fail.
+- A fresh install (`db create`) already creates the v4 schema; no upgrade needed.
+
+---
+
+## UI apps
+
+### What changed on the API
+
+| Endpoint | Change |
+| --- | --- |
+| `GET /api/photos` | Now **public** (was owner-only). Logged-in owner → all photos; guest → photostream members (empty if unset). Honors paging + ordering. |
+| `GET /api/user` | Now returns `photoStreamAlbumId` (owner only — blank for anonymous callers). |
+| `PUT /api/user/photostream` | **New** owner-only setter for the photostream album id. |
+| `GET /api/user/config` / `PUT /api/user/config` | Unchanged. The config blob still round-trips `photoStreamAlbumId`, but the server no longer reads it from there. |
+
+### Backward compatibility
+
+The deployed UI needs no immediate change because:
+
+- `GET /api/user/config` still returns `photoStreamAlbumId` in the blob, so the old
+  UI reads it exactly as before.
+- The old UI only calls `GET /api/photos` while logged in as the owner, where the
+  response is unchanged (all photos). Making the route public is a widening, not a
+  break.
+- `photoStreamAlbumId` on `GET /api/user` is a new field older parsers ignore.
+
+### Required changes to adopt the new model
+
+1. **Read** the photostream id from `GET /api/user` (`user.photoStreamAlbumId`)
+   instead of from the config blob.
+2. **Write** it via `PUT /api/user/photostream` (body `{ "photoStreamAlbumId":
+   "<album-uuid>" }`; an empty string clears it) — point the UX-config album picker
+   here instead of stuffing it into the config blob.
+3. **Remove** `photoStreamAlbumId` from the `UXConfig` type / defaults.
+4. **Fetch photos** through `GET /api/photos` for both owner and guest, dropping the
+   `isUser` branch that chose between `getPhotos()` and `getAlbumPhotos(streamId)`.
+
+### Transition caveat (dual source of truth)
+
+Between deploying the v4 backend and shipping the UI change, the id lives in **two**
+places: the config blob (old UI reads/writes) and the new column (server reads).
+The migration seeds them in sync. If you change the photostream from the **old** UI
+after deploy, it updates the blob but not the column — harmless today (nothing yet
+uses the guest `/photos` path), but re-set it via `PUT /api/user/photostream` after
+the UI is updated, or just deploy backend + UI together. Once every client reads
+from `/api/user`, the `photoStreamAlbumId` key can be dropped from the config blob
+(optional cleanup).
+
+---
+
+## `GET /api/photos` — endpoint reference
+
+Public (session cookie optional).
+
+- **Owner** (logged in): every photo.
+- **Guest** (anonymous): members of the photostream album, or an empty list if no
+  photostream is set.
+
+### Query parameters
+
+Decoded from the query string; keys are case-insensitive.
+
+| Param | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `limit` | int | `0` | Page size. **`0` means no limit** (return everything) — this preserves the old behavior. |
+| `offset` | int | `0` | Rows to skip. Negative is treated as `0`. |
+| `orderBy` | int enum | `0` | Sort order (see below). |
+
+`orderBy` values (the `PhotoOrder` enum):
+
+| Value | Order |
+| --- | --- |
+| `0` | None → defaults to newest upload first |
+| `1` | Upload date, newest first |
+| `2` | Original (capture) date, newest first |
+| `3` | Manual album order → not meaningful here; treated as upload date |
+
+Ordering always applies a stable `id` tie-breaker, so `limit`/`offset` paging never
+drops or repeats a row across pages.
+
+> **Only send parameters this backend version declares.** Unknown query keys are
+> rejected with a 400. In particular, do **not** send `cameraModel` etc. yet — see
+> the next section.
+
+### Response
+
+Standard `{ data }` / `{ error }` envelope (always transport-200; the real status is
+in `error.code`). On success:
+
+```json
+{ "data": { "length": 12, "photos": [ { "id": "...", "title": "...", ... } ] } }
+```
+
+`length` is the size of the returned page, **not** a grand total — there is no total
+count yet, so compute "has more" from whether a full page came back.
+
+---
+
+## Server-side filtering — next backend release
+
+Equipment filters are **not in v4**. The next backend release adds these query
+parameters to `GET /api/photos`, all exact-match:
+
+- `cameraModel`
+- `cameraMake`
+- `lensModel`
+- `lensMake`
+
+They work on both the owner and guest views (a guest filter is applied within the
+photostream). Until that release ships, sending any of them returns a 400, so keep
+doing camera-model filtering client-side for now. This section will be updated to
+"available" when the filtering release lands.

--- a/internal/dao/dao.go
+++ b/internal/dao/dao.go
@@ -90,7 +90,7 @@ type PhotoDAO interface {
 	Get(id uuid.UUID) (*Photo, error)
 	List() ([]*Photo, error)
 	ListSource(source string) ([]*Photo, error)
-	//Select(r Range, order PhotoOrder, filter PhotoFilter) ([]*Photo, error)
+	Select(filter PhotoFilter, r Range, order PhotoOrder) ([]*Photo, error)
 	//SetPrivate(private bool, id uuid.UUID) (*Photo, error)
 	Set(title string, description string, keywords []string, id uuid.UUID) (*Photo, error)
 	SetAlbums(id uuid.UUID, albumIds []uuid.UUID) (int, error)
@@ -176,7 +176,7 @@ func (pgd *PGDB) tableExists(table string) bool {
 }
 
 func (pgd *PGDB) CreateTables() error {
-	if _, err := pgd.db.Exec(schemaV3); err != nil {
+	if _, err := pgd.db.Exec(schemaV4); err != nil {
 		return err
 	} else { //make sure version is correct
 		_, err = pgd.Version.Update()
@@ -188,6 +188,6 @@ func (pgd *PGDB) CreateTables() error {
 }
 
 func (pgd *PGDB) DeleteTables() error {
-	_, err := pgd.db.Exec(deleteSchemaV3)
+	_, err := pgd.db.Exec(deleteSchemaV4)
 	return err
 }

--- a/internal/dao/migrate.go
+++ b/internal/dao/migrate.go
@@ -1,6 +1,7 @@
 package dao
 
 import (
+	"encoding/json"
 	"fmt"
 )
 
@@ -29,7 +30,7 @@ func UpgradeDb() error {
 			logger.Info("Database is up to date")
 			return nil
 		} else if canUpgradeDb(pgdb) {
-			return upgradeToV3(pgdb)
+			return upgradeToV4(pgdb)
 		} else {
 			return fmt.Errorf("cannot upgrade database, wrong current version")
 		}
@@ -44,44 +45,38 @@ func UpgradeDb() error {
 	return nil
 }
 
-func upgradeToV3(pgdb *PGDB) error {
+func upgradeToV4(pgdb *PGDB) error {
 	logger.Infow("Upgrading Db to Version", "version", DbVersion)
 
-	var err error
-	var v *Version
-	var a *Album
-	var photos []*Photo
-
-	if _, err = pgdb.db.Exec(schemaV2toV3); err != nil {
+	if _, err := pgdb.db.Exec(schemaV3toV4); err != nil {
 		return err
 	}
 
 	logger.Info("Db Updated. Change Version Info")
-	if v, err = pgdb.Version.Update(); err != nil {
+	if v, err := pgdb.Version.Update(); err != nil {
 		return err
 	} else {
 		logger.Infow("Updated Db to version", "version", v.VersionId)
 	}
-	logger.Info("create photo stream album")
-	if a, err = pgdb.Album.Add("photostream", "Default public photostream", ""); err != nil {
-		return err
+
+	// Seed the new typed column once from the client config blob — the only place
+	// the photostream album id lived before this version. This is the single
+	// appropriate spot to read that blob; the running server never does.
+	var config string
+	if err := pgdb.db.Get(&config, "SELECT config FROM usert LIMIT 1"); err != nil {
+		logger.Warnw("could not read user config while seeding photostream id; leaving it unset", "error", err)
+		return nil
 	}
-
-	logger.Info("Add all public photos to it")
-
-	if err = pgdb.db.Select(&photos, "SELECT * FROM img WHERE private = false"); err != nil {
-		return err
+	var conf map[string]interface{}
+	if err := json.Unmarshal([]byte(config), &conf); err != nil {
+		logger.Warnw("could not parse user config while seeding photostream id; leaving it unset", "error", err)
+		return nil
 	}
-
-	const addAlbumPhoto = "INSERT INTO albumphotos (albumId, photoId) VALUES ($1, $2)"
-	for _, p := range photos {
-		if _, err := pgdb.db.Exec(addAlbumPhoto, a.Id, p.Id); err != nil {
-			return nil
+	if id, ok := conf["photoStreamAlbumId"].(string); ok && id != "" {
+		if _, err := pgdb.db.Exec("UPDATE usert SET photostreamalbumid = $1", id); err != nil {
+			return err
 		}
+		logger.Infow("seeded photostream album id from config", "id", id)
 	}
-
-	//finally delete the private column
-	logger.Info("Drop the private column from image")
-	_, err = pgdb.db.Exec("ALTER TABLE img DROP COLUMN private")
-	return err
+	return nil
 }

--- a/internal/dao/migrate_test.go
+++ b/internal/dao/migrate_test.go
@@ -1,0 +1,81 @@
+package dao
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// TestUpgradeToV4Seed rewinds a freshly created (v4) database to the v3 shape —
+// no photostreamalbumid column, version 3, the album id living only in the config
+// blob — then runs upgradeToV4 and asserts the column is seeded from that blob.
+// The drop/recreate harness only ever creates the latest schema, so this is the
+// only coverage of the migration seed path.
+func TestUpgradeToV4Seed(t *testing.T) {
+	pgdb := openAndCreateTestDb(t)
+	defer deleteAndCloseTestDb(pgdb, t)
+
+	streamID := uuid.New().String()
+
+	// Rewind to v3: drop the new column, mark the db version 3, and stash the
+	// photostream id in the config blob the way the old clients did.
+	if _, err := pgdb.db.Exec("ALTER TABLE usert DROP COLUMN photostreamalbumid"); err != nil {
+		t.Fatalf("could not drop column to simulate v3: %v", err)
+	}
+	if _, err := pgdb.db.Exec("UPDATE version SET versionId = 3"); err != nil {
+		t.Fatalf("could not set version to 3: %v", err)
+	}
+	if _, err := pgdb.db.Exec(`UPDATE usert SET config = $1`,
+		`{"photoStreamAlbumId":"`+streamID+`","photoGridCols":3}`); err != nil {
+		t.Fatalf("could not seed config blob: %v", err)
+	}
+
+	if err := upgradeToV4(pgdb); err != nil {
+		t.Fatalf("upgradeToV4 failed: %v", err)
+	}
+
+	// Version bumped.
+	if v, err := pgdb.Version.Get(); err != nil {
+		t.Fatalf("could not read version: %v", err)
+	} else if v.VersionId != DbVersion {
+		t.Errorf("expected version %d got %d", DbVersion, v.VersionId)
+	}
+
+	// Column exists and was seeded from the blob.
+	user, err := pgdb.User.Get()
+	if err != nil {
+		t.Fatalf("could not read user after upgrade: %v", err)
+	}
+	if user.PhotoStreamAlbumId != streamID {
+		t.Errorf("expected seeded photoStreamAlbumId %q got %q", streamID, user.PhotoStreamAlbumId)
+	}
+}
+
+// TestUpgradeToV4NoSeed verifies the migration is resilient when the config blob
+// has no photostream id: the column is added and left empty, not errored.
+func TestUpgradeToV4NoSeed(t *testing.T) {
+	pgdb := openAndCreateTestDb(t)
+	defer deleteAndCloseTestDb(pgdb, t)
+
+	if _, err := pgdb.db.Exec("ALTER TABLE usert DROP COLUMN photostreamalbumid"); err != nil {
+		t.Fatalf("could not drop column to simulate v3: %v", err)
+	}
+	if _, err := pgdb.db.Exec("UPDATE version SET versionId = 3"); err != nil {
+		t.Fatalf("could not set version to 3: %v", err)
+	}
+	if _, err := pgdb.db.Exec(`UPDATE usert SET config = '{}'`); err != nil {
+		t.Fatalf("could not reset config blob: %v", err)
+	}
+
+	if err := upgradeToV4(pgdb); err != nil {
+		t.Fatalf("upgradeToV4 failed: %v", err)
+	}
+
+	user, err := pgdb.User.Get()
+	if err != nil {
+		t.Fatalf("could not read user after upgrade: %v", err)
+	}
+	if user.PhotoStreamAlbumId != "" {
+		t.Errorf("expected empty photoStreamAlbumId, got %q", user.PhotoStreamAlbumId)
+	}
+}

--- a/internal/dao/photo.go
+++ b/internal/dao/photo.go
@@ -187,6 +187,55 @@ func (dao *PhotoPG) ListSource(source string) ([]*Photo, error) {
 	return ret, err
 }
 
+// Select returns photos honoring an optional album scope, an order and a page.
+// filter.AlbumId (set server-side, never by a client) limits the result to that
+// album's members — this is how the public photo list is confined to the
+// photostream. A zero Range.Limit means "no limit" (return everything), which
+// preserves the historic behavior of List.
+func (dao *PhotoPG) Select(filter PhotoFilter, r Range, order PhotoOrder) ([]*Photo, error) {
+	var stmt strings.Builder
+	stmt.WriteString("SELECT * FROM img")
+
+	var where []string
+	var args []interface{}
+	if filter.AlbumId != nil {
+		args = append(args, *filter.AlbumId)
+		where = append(where, fmt.Sprintf("id IN (SELECT photoid FROM albumphotos WHERE albumid = $%d)", len(args)))
+	}
+	if len(where) > 0 {
+		stmt.WriteString(" WHERE ")
+		stmt.WriteString(strings.Join(where, " AND "))
+	}
+
+	stmt.WriteString(orderByClause(order))
+
+	if r.Limit > 0 {
+		offset := r.Offset
+		if offset < 0 {
+			offset = 0
+		}
+		args = append(args, r.Limit, offset)
+		fmt.Fprintf(&stmt, " LIMIT $%d OFFSET $%d", len(args)-1, len(args))
+	}
+
+	ret := []*Photo{}
+	err := dao.db.Select(&ret, stmt.String(), args...)
+	return ret, err
+}
+
+// orderByClause maps a PhotoOrder to a stable ORDER BY with a deterministic
+// tie-breaker on id, so LIMIT/OFFSET paging cannot drop or repeat rows across
+// pages. The flat photo list has no album row-order, so None and ManualOrder
+// fall back to upload date (the historic default of List).
+func orderByClause(order PhotoOrder) string {
+	switch order {
+	case OriginalDate:
+		return " ORDER BY originaldate DESC, id"
+	default: // None, UploadDate, ManualOrder
+		return " ORDER BY uploaddate DESC, id"
+	}
+}
+
 func (dao *PhotoPG) Set(title string, description string, keywords []string, id uuid.UUID) (*Photo, error) {
 	//join keywords
 	var b strings.Builder

--- a/internal/dao/photo_select_test.go
+++ b/internal/dao/photo_select_test.go
@@ -1,0 +1,155 @@
+package dao
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// mkSelectPhoto builds a Photo with all NOT NULL columns populated, varying only
+// the fields the Select tests care about (camera model, upload and original date).
+func mkSelectPhoto(model string, upload, original time.Time) Photo {
+	return Photo{
+		Id:           uuid.New(),
+		Md5:          uuid.New().String(),
+		Source:       "local",
+		UploadDate:   upload,
+		OriginalDate: original,
+		FileName:     model + ".jpg",
+		Title:        model,
+		CameraMake:   "TestMake",
+		CameraModel:  model,
+		Iso:          100,
+		FNumber:      2.8,
+		Exposure:     "1/100",
+		Width:        1000,
+		Height:       800,
+	}
+}
+
+func idsOf(photos []*Photo) []uuid.UUID {
+	ids := make([]uuid.UUID, len(photos))
+	for i, p := range photos {
+		ids[i] = p.Id
+	}
+	return ids
+}
+
+func TestPhotoSelect(t *testing.T) {
+	pgdb := openAndCreateTestDb(t)
+	defer deleteAndCloseTestDb(pgdb, t)
+
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	// Upload dates: pA > pB > (pC == pD). The pC/pD tie exercises the id
+	// tie-breaker. Original dates are all distinct and in a different order than
+	// upload dates, so an OriginalDate sort must differ from an UploadDate sort.
+	pA := mkSelectPhoto("Alpha", base.Add(3*time.Hour), base.Add(1*time.Hour))
+	pB := mkSelectPhoto("Beta", base.Add(2*time.Hour), base.Add(4*time.Hour))
+	pC := mkSelectPhoto("Alpha", base.Add(1*time.Hour), base.Add(2*time.Hour))
+	pD := mkSelectPhoto("Gamma", base.Add(1*time.Hour), base.Add(3*time.Hour))
+
+	for _, p := range []Photo{pA, pB, pC, pD} {
+		pc := p
+		if err := pgdb.Photo.Add(&pc, nil); err != nil {
+			t.Fatalf("could not add photo %s: %v", p.Title, err)
+		}
+	}
+
+	// the tie pair (pC, pD) ordered by id ascending, matching Postgres UUID order
+	tieLo, tieHi := pC, pD
+	if bytes.Compare(pC.Id[:], pD.Id[:]) > 0 {
+		tieLo, tieHi = pD, pC
+	}
+
+	// 1. No filter, no paging: all photos, uploaddate DESC with id tie-breaker.
+	if photos, err := pgdb.Photo.Select(PhotoFilter{}, Range{}, UploadDate); err != nil {
+		t.Fatalf("Select all failed: %v", err)
+	} else {
+		want := []uuid.UUID{pA.Id, pB.Id, tieLo.Id, tieHi.Id}
+		if got := idsOf(photos); !equalIDs(got, want) {
+			t.Errorf("uploaddate order: expected %v got %v", want, got)
+		}
+	}
+
+	// 2. None order falls back to uploaddate DESC (historic List behavior).
+	if photos, err := pgdb.Photo.Select(PhotoFilter{}, Range{}, None); err != nil {
+		t.Fatalf("Select None failed: %v", err)
+	} else {
+		want := []uuid.UUID{pA.Id, pB.Id, tieLo.Id, tieHi.Id}
+		if got := idsOf(photos); !equalIDs(got, want) {
+			t.Errorf("None order: expected uploaddate fallback %v got %v", want, got)
+		}
+	}
+
+	// 3. OriginalDate order is distinct and total.
+	if photos, err := pgdb.Photo.Select(PhotoFilter{}, Range{}, OriginalDate); err != nil {
+		t.Fatalf("Select OriginalDate failed: %v", err)
+	} else {
+		want := []uuid.UUID{pB.Id, pD.Id, pC.Id, pA.Id}
+		if got := idsOf(photos); !equalIDs(got, want) {
+			t.Errorf("originaldate order: expected %v got %v", want, got)
+		}
+	}
+
+	// 4. Paging is stable across the tie: two disjoint pages cover all rows with
+	// no duplicate or dropped row.
+	page1, err := pgdb.Photo.Select(PhotoFilter{}, Range{Limit: 2, Offset: 0}, UploadDate)
+	if err != nil {
+		t.Fatalf("page1 failed: %v", err)
+	}
+	page2, err := pgdb.Photo.Select(PhotoFilter{}, Range{Limit: 2, Offset: 2}, UploadDate)
+	if err != nil {
+		t.Fatalf("page2 failed: %v", err)
+	}
+	if len(page1) != 2 || len(page2) != 2 {
+		t.Fatalf("expected two pages of 2, got %d and %d", len(page1), len(page2))
+	}
+	seen := map[uuid.UUID]bool{}
+	for _, id := range append(idsOf(page1), idsOf(page2)...) {
+		if seen[id] {
+			t.Errorf("paging returned duplicate id %v", id)
+		}
+		seen[id] = true
+	}
+	if len(seen) != 4 {
+		t.Errorf("paging did not cover all 4 photos, got %d distinct", len(seen))
+	}
+
+	// 5. Limit == 0 means no limit — all rows.
+	if photos, err := pgdb.Photo.Select(PhotoFilter{}, Range{Limit: 0, Offset: 0}, UploadDate); err != nil {
+		t.Fatalf("Select limit 0 failed: %v", err)
+	} else if len(photos) != 4 {
+		t.Errorf("limit 0 should return all 4, got %d", len(photos))
+	}
+
+	// 6. AlbumId scopes the result to that album's members only.
+	album, err := pgdb.Album.Add("scopealbum", "desc", "")
+	if err != nil {
+		t.Fatalf("could not add album: %v", err)
+	}
+	if _, err := pgdb.Album.AddPhotos(album.Id, []uuid.UUID{pA.Id, pC.Id}); err != nil {
+		t.Fatalf("could not add photos to album: %v", err)
+	}
+	if photos, err := pgdb.Photo.Select(PhotoFilter{AlbumId: &album.Id}, Range{}, UploadDate); err != nil {
+		t.Fatalf("Select by album failed: %v", err)
+	} else {
+		want := []uuid.UUID{pA.Id, pC.Id} // pA upload 3h, pC upload 1h
+		if got := idsOf(photos); !equalIDs(got, want) {
+			t.Errorf("album scope: expected %v got %v", want, got)
+		}
+	}
+}
+
+func equalIDs(a, b []uuid.UUID) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/dao/schema.go
+++ b/internal/dao/schema.go
@@ -1,11 +1,11 @@
 package dao
 
-const schemaV2toV3 = `
-	ALTER TABLE album ADD COLUMN code TEXT, ADD COLUMN orderBy INTEGER;
-	UPDATE album SET code = '', orderBy = 0;
-	ALTER TABLE album ALTER COLUMN code SET NOT NULL, ALTER COLUMN orderBy SET NOT NULL;
+// schemaV3toV4 adds the photostreamalbumid column to usert. It is seeded from
+// the existing config blob by upgradeToV4 (schema.go can't read the old value).
+const schemaV3toV4 = `
+	ALTER TABLE usert ADD COLUMN photostreamalbumid TEXT NOT NULL DEFAULT '';
 `
-const schemaV3 = `
+const schemaV4 = `
 CREATE TABLE IF NOT EXISTS album (
 	Id UUID,
 	name TEXT,
@@ -127,6 +127,7 @@ CREATE TABLE IF NOT EXISTS usert (
 	pic TEXT NOT NULL,
 	driveFolderId TEXT NOT NULL,
 	driveFolderName TEXT NOT NULL,
+	photostreamalbumid TEXT NOT NULL DEFAULT '',
 	config TEXT NOT NULL
 );
 
@@ -142,7 +143,7 @@ INSERT INTO version (versionId,description) VALUES (0,'no version set') ON CONFL
 INSERT INTO usert (id, name, bio, pic, driveFolderId, driveFolderName, config) VALUES (23657, '', '', '', '','','{}') ON CONFLICT (id) DO NOTHING;
 `
 
-const deleteSchemaV3 = `
+const deleteSchemaV4 = `
 DROP TABLE IF EXISTS album;
 DROP TABLE IF EXISTS albumphotos;
 DROP TABLE IF EXISTS camera;

--- a/internal/dao/types.go
+++ b/internal/dao/types.go
@@ -6,8 +6,8 @@ import (
 	"time"
 )
 
-const DbVersion = 3
-const DbDescription = "Version 3 adds simple access control to albums and makes public access based on a default photo stream album"
+const DbVersion = 4
+const DbDescription = "Version 4 promotes the photo stream album id to a typed user column"
 
 type Album struct {
 	Id          uuid.UUID  `json:"id"`
@@ -114,8 +114,11 @@ type Photo struct {
 }
 
 type PhotoFilter struct {
-	//Private     bool
 	CameraModel string
+	// AlbumId scopes the result to members of one album. It is set server-side
+	// (never decoded from a client) and is how the public photo list is limited
+	// to the photostream. nil means no album scope (all photos).
+	AlbumId *uuid.UUID
 }
 
 type PhotoOrder int
@@ -142,12 +145,13 @@ const SourceGoogle = "gdrive"
 const SourceLocal = "local"
 
 type User struct {
-	Name            string `json:"name"`
-	Bio             string `json:"bio"`
-	Pic             string `json:"pic"`
-	DriveFolderId   string `json:"driveFolderId,omitempty"`
-	DriveFolderName string `json:"driveFolderName,omitempty"`
-	Config          string `json:"config,omitempty"`
+	Name               string `json:"name"`
+	Bio                string `json:"bio"`
+	Pic                string `json:"pic"`
+	DriveFolderId      string `json:"driveFolderId,omitempty"`
+	DriveFolderName    string `json:"driveFolderName,omitempty"`
+	PhotoStreamAlbumId string `json:"photoStreamAlbumId"`
+	Config             string `json:"config,omitempty"`
 }
 
 type Version struct {

--- a/internal/dao/user_test.go
+++ b/internal/dao/user_test.go
@@ -88,6 +88,17 @@ func TestUsers(t *testing.T) {
 		t.Errorf("Actual config is different from expected config")
 	}
 
+	//PhotoStreamAlbumId round-trips as a typed column
+	u.PhotoStreamAlbumId = "b3b8c0de-0000-0000-0000-000000000001"
+	if _, err = pgdb.User.Update(u); err != nil {
+		t.Errorf("could not update photostream album id: %s", err.Error())
+	}
+	if got, err := pgdb.User.Get(); err != nil {
+		t.Errorf("could not retrieve user: %s", err.Error())
+	} else if got.PhotoStreamAlbumId != u.PhotoStreamAlbumId {
+		t.Errorf("expected photoStreamAlbumId %q got %q", u.PhotoStreamAlbumId, got.PhotoStreamAlbumId)
+	}
+
 	//Dont accept non json config
 	u.Config = "some non json string"
 	if _, err = pgdb.User.Update(u); err == nil {

--- a/internal/server/photos.go
+++ b/internal/server/photos.go
@@ -200,24 +200,47 @@ func (s *mserver) handlePhoto(w http.ResponseWriter, r *http.Request) (interface
 	}
 }
 
-func (s *mserver) handlePhotos(r *http.Request) (interface{}, error) {
+// handlePhotos lists photos with optional paging and ordering. It is public
+// (loginInfo): a logged-in owner gets every photo, while a guest gets only the
+// members of the photostream album. That album is a typed user setting; if it is
+// unset, guests get an empty list.
+func (s *mserver) handlePhotos(r *http.Request, loggedIn bool) (interface{}, error) {
 	type request struct {
-		Limit  int
-		Offset int
+		Limit   int
+		Offset  int
+		OrderBy dao.PhotoOrder
 	}
 	var params request
 	if err := decodeRequest(r, &params); err != nil {
 		return nil, err
-	} else {
-		//dao.Range{Offset: params.Offset, Limit: params.Limit}
-		if photos, e1 := s.pg.Photo.List(); e1 != nil {
-			return nil, e1
-		} else {
-			return &PhotoFiles{Length: len(photos), Photos: photos}, nil
-		}
-
 	}
 
+	order := params.OrderBy
+	if order == dao.None {
+		order = dao.UploadDate
+	}
+
+	var filter dao.PhotoFilter
+	if !loggedIn {
+		user, err := s.pg.User.Get()
+		if err != nil {
+			return nil, err
+		}
+		if user.PhotoStreamAlbumId == "" {
+			return &PhotoFiles{Length: 0, Photos: []*dao.Photo{}}, nil
+		}
+		albumId, err := uuid.Parse(user.PhotoStreamAlbumId)
+		if err != nil {
+			return nil, InternalError("stored photostream album id is not a valid uuid")
+		}
+		filter.AlbumId = &albumId
+	}
+
+	photos, err := s.pg.Photo.Select(filter, dao.Range{Offset: params.Offset, Limit: params.Limit}, order)
+	if err != nil {
+		return nil, err
+	}
+	return &PhotoFiles{Length: len(photos), Photos: photos}, nil
 }
 
 // handleUpdatePhoto updates the photo named by {photoid}. The path identifies the photo;

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -53,7 +53,7 @@ func (s *mserver) routes() {
 	s.mGET("/logout", s.mResponse(s.handleLogout))
 	s.mGET("/loggedin", s.loginInfo(s.handleLoggedIn))
 
-	s.mGET("/photos", s.authOnly(s.handlePhotos))
+	s.mGET("/photos", s.loginInfo(s.handlePhotos))
 	s.mDELETE("/photos", s.authOnly(s.handleDeletePhotos))
 	s.mGET("/photos/{photoid}/albums", s.loginInfo(s.handlePhotoAlbums))
 	s.mPUT("/photos/{photoid}/albums/add", s.authOnly(s.handleAddPhotoAlbums))
@@ -85,6 +85,7 @@ func (s *mserver) routes() {
 	s.mPUT("/user", s.authOnly(s.handleUpdateUser))
 	s.mPUT("/user/pic", s.authOnly(s.handleUpdatePicUser))
 	s.mPUT("/user/gdrive", s.authOnly(s.handleUpdateDriveUser))
+	s.mPUT("/user/photostream", s.authOnly(s.handleUpdatePhotostream))
 	s.mGET("/user/config", s.mResponse(s.handleUserConfig))
 	s.mPUT("/user/config", s.authOnly(s.handleUpdateConfig))
 }

--- a/internal/server/user.go
+++ b/internal/server/user.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"github.com/google/uuid"
 	"github.com/msvens/mphotos/internal/dao"
 	"net/http"
 )
@@ -11,11 +12,41 @@ func (s *mserver) handleUser(r *http.Request, loggedIn bool) (interface{}, error
 		if !loggedIn {
 			u.DriveFolderId = ""
 			u.DriveFolderName = ""
+			u.PhotoStreamAlbumId = ""
 		}
 		return u, nil
 	} else {
 		return nil, err
 	}
+}
+
+// handleUpdatePhotostream sets the album whose members make up the public photo
+// stream. It mirrors handleUpdateDriveUser: a typed, owner-only setter for a
+// server-critical value that used to live in the client config blob. An empty
+// id clears the stream.
+func (s *mserver) handleUpdatePhotostream(r *http.Request) (interface{}, error) {
+	type request struct {
+		PhotoStreamAlbumId string `json:"photoStreamAlbumId" schema:"photoStreamAlbumId"`
+	}
+	var params request
+	if err := decodeRequest(r, &params); err != nil {
+		return nil, err
+	}
+	if params.PhotoStreamAlbumId != "" {
+		id, err := uuid.Parse(params.PhotoStreamAlbumId)
+		if err != nil {
+			return nil, BadRequestError("photoStreamAlbumId is not a valid uuid")
+		}
+		if !s.pg.Album.Has(id) {
+			return nil, NotFoundError("Album not found: " + params.PhotoStreamAlbumId)
+		}
+	}
+	user, err := s.pg.User.Get()
+	if err != nil {
+		return nil, InternalError(err.Error())
+	}
+	user.PhotoStreamAlbumId = params.PhotoStreamAlbumId
+	return s.pg.User.Update(user)
 }
 
 func (s *mserver) handleUserConfig(_ http.ResponseWriter, r *http.Request) (interface{}, error) {


### PR DESCRIPTION
First of two PRs toward server-side photo filtering (bug #2). This one lays the groundwork: a schema migration + the auth-surface change. Equipment filters follow in PR B.

## What & why

The photo stream album id lived in the client-owned `UXConfig` blob (`User.Config`), which the server stored verbatim and never parsed. That was fine until now — but to serve the public photostream from `/api/photos`, the server needs to know which album is public, and it should not reverse-engineer a client-dictated JSON object to make an authorization decision.

So this PR:

- **Promotes `photoStreamAlbumId` to a typed `usert` column** (`DbVersion` 3 → 4), mirroring `driveFolderId`/`driveFolderName`, which are already typed columns for exactly this reason. It's the only server-critical key in an otherwise pure-presentation config blob.
- **Makes `GET /api/photos` public** (`authOnly` → `loginInfo`): a logged-in owner gets every photo; a guest gets only the members of the photostream album (empty if unset, never a fall-through to "all"). This collapses the owner-vs-guest fetch branch both frontends repeat at every callsite.
- Adds **paging + ordering** to that endpoint, with a stable `id` tie-breaker so `limit`/`offset` can't drop or repeat rows across pages. `limit=0` still means "all", preserving current behavior.

## Changes

- **Schema** — `schemaV3toV4` adds `photostreamalbumid TEXT NOT NULL DEFAULT ''`; `upgradeToV4` seeds it once from the old config blob (the single appropriate place to read that blob). Follows the repo's single-step migration convention (replaces `upgradeToV3`/`schemaV2toV3`).
- **DAO** — `PhotoPG.Select(filter, range, order)` scopes by optional album membership, orders (with tie-breaker), and pages. `User` gains a typed `PhotoStreamAlbumId`.
- **Server** — `handlePhotos` becomes `loginInfo` and branches owner/guest; new owner-only `PUT /api/user/photostream` setter (mirrors `PUT /api/user/gdrive`); `GET /api/user` returns the id, blanked for anonymous callers.

## Backward compatibility

Not a breaking change for the deployed UI. The config blob is untouched (old UI still reads `photoStreamAlbumId` from it), the old UI only calls `/api/photos` as the owner (response unchanged), and the new `GET /api/user` field is ignored by older parsers. Making the route public is a widening. See `MIGRATION.md` for the required `db upgrade` step and the (optional, later) UI adoption notes.

## Testing

`make ci` green. New DAO tests (the package with a live-Postgres harness):
- `photo_select_test.go` — album scope, upload/original ordering, **stable paging across a deliberate date tie**, `limit=0`.
- `migrate_test.go` — the seed path (rewinds a fresh DB to v3 shape, runs `upgradeToV4`, asserts the column is seeded) plus the no-id resilience case.
- `user_test.go` — `PhotoStreamAlbumId` round-trip.

## Deploy note

Requires `./mphotos db upgrade` before serving — the server doesn't auto-migrate, and the new binary's user queries select the new column. Documented in `MIGRATION.md`.