### PR TITLE
Add equipment filters to /api/photos

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,7 +3,7 @@
 This release promotes the **photo stream album id** from the client-owned config
 blob to a typed server column, and makes `GET /api/photos` a public endpoint that
 serves the photostream to guests and the full library to the owner. It also adds
-paging and ordering to that endpoint.
+equipment filtering, paging and ordering to that endpoint.
 
 It has two audiences:
 
@@ -118,6 +118,14 @@ Decoded from the query string; keys are case-insensitive.
 | `limit` | int | `0` | Page size. **`0` means no limit** (return everything) — this preserves the old behavior. |
 | `offset` | int | `0` | Rows to skip. Negative is treated as `0`. |
 | `orderBy` | int enum | `0` | Sort order (see below). |
+| `cameraModel` | string | — | Exact-match equipment filter, applied only when non-empty. |
+| `cameraMake` | string | — | Exact-match equipment filter. |
+| `lensModel` | string | — | Exact-match equipment filter. |
+| `lensMake` | string | — | Exact-match equipment filter. |
+
+Multiple filters combine with AND. On the guest view they apply within the
+photostream (e.g. `?cameraModel=Leica%20M11` returns only photostream photos shot
+with that model).
 
 `orderBy` values (the `PhotoOrder` enum):
 
@@ -132,8 +140,7 @@ Ordering always applies a stable `id` tie-breaker, so `limit`/`offset` paging ne
 drops or repeats a row across pages.
 
 > **Only send parameters this backend version declares.** Unknown query keys are
-> rejected with a 400. In particular, do **not** send `cameraModel` etc. yet — see
-> the next section.
+> rejected with a 400, so send only the parameters listed above.
 
 ### Response
 
@@ -149,17 +156,13 @@ count yet, so compute "has more" from whether a full page came back.
 
 ---
 
-## Server-side filtering — next backend release
+## Server-side filtering
 
-Equipment filters are **not in v4**. The next backend release adds these query
-parameters to `GET /api/photos`, all exact-match:
+Equipment filters (`cameraModel`, `cameraMake`, `lensModel`, `lensMake`) are live —
+see the query-parameter table above. They are exact-match, combine with AND, and
+apply on both the owner and guest views (a guest filter is scoped to the
+photostream).
 
-- `cameraModel`
-- `cameraMake`
-- `lensModel`
-- `lensMake`
-
-They work on both the owner and guest views (a guest filter is applied within the
-photostream). Until that release ships, sending any of them returns a 400, so keep
-doing camera-model filtering client-side for now. This section will be updated to
-"available" when the filtering release lands.
+For the UI, this means the camera page can call
+`GET /api/photos?cameraModel=<model>` for both audiences and drop the client-side
+`.filter(p => p.cameraModel === model)` along with the `isUser` fetch branch.

--- a/discovered-bugs.md
+++ b/discovered-bugs.md
@@ -9,7 +9,7 @@ fix. Newest issues can be appended at the end.
 | # | Issue | Status |
 | --- | --- | --- |
 | 1 | `handleCamera` reads the wrong path variable | **fixed** |
-| 2 | `GET /api/photos` ignores filter and paging | deferred — a feature, not a bugfix |
+| 2 | `GET /api/photos` ignores filter and paging | **fixed** |
 | 3 | `handlePhotos` swallows DAO errors | **fixed** |
 | 4 | `GET /api/likes/{photoid}` leaks guest emails | **fixed** |
 | 5 | `handleCameraImage` writes the response twice | **fixed** |
@@ -17,7 +17,7 @@ fix. Newest issues can be appended at the end.
 | 7 | Update handlers ignore the id in the URL | **fixed** |
 | 8 | Photos in code-protected albums reachable by direct id | **closed — by design** |
 
-Only #2 remains, deliberately deferred — see its entry for why.
+All eight are resolved.
 
 ---
 
@@ -33,22 +33,26 @@ Only #2 remains, deliberately deferred — see its entry for why.
 - **Frontend impact:** the camera detail page works around this by finding the camera in the
   `GET /api/cameras` list instead of calling the single-camera endpoint.
 
-## 2. `GET /api/photos` ignores its filter and paging
+## 2. `GET /api/photos` ignores its filter and paging — FIXED
 
 - **Where:** `internal/server/photos.go:203` (`handlePhotos`).
-- **Symptom:** it decodes a `{Limit, Offset}` request body, but the `dao.Range` line is commented
-  out and it calls `s.pg.Photo.List()`, returning **all** photos regardless of `Limit`/`Offset`. It
-  also never reads a `cameraModel` (or any other) filter. The route is `authOnly`
-  (`routes.go:56`), so guests can't call it at all.
-- **Consequence:** there is no working "photos filtered by camera model" endpoint. Camera-model
-  filtering must go through the album-photos endpoint (`/api/albums/{albumid}/photos`, which does
-  honor a `CameraModel` filter) or be done client-side. The frontend's `getPhotosByCameraModel`
-  (which hits `/api/photos?cameraModel=`) is effectively dead and unused.
-- **Fix (if paging/filtering is wanted):** decode and apply `Limit`/`Offset` (and optionally a
-  `CameraModel` filter) via `Photo.List` with a range/filter instead of the argument-less call.
-  Note `Photo.List()` (`internal/dao/photo.go:178`) takes no arguments, so this needs a new DAO
-  method — `AlbumPG.SelectPhotos` (`internal/dao/album.go:135`) is the template to copy.
-- **Also in the same statement:** see #3 below — the error from `List()` is silently swallowed.
+- **Symptom:** it decoded a `{Limit, Offset}` request, but the `dao.Range` line was commented out
+  and it called `s.pg.Photo.List()`, returning **all** photos regardless of `Limit`/`Offset`. It
+  also never read a `cameraModel` (or any other) filter. The route was `authOnly`, so guests
+  couldn't call it at all.
+- **Fixed** across two PRs, which also reshaped the endpoint:
+  - The route is now `loginInfo` (public): the owner gets all photos, a guest gets only the
+    photostream album's members. This required promoting the photostream album id out of the client
+    config blob into a typed `usert` column (`DbVersion` 4). See `MIGRATION.md`.
+  - A new `PhotoPG.Select(filter, range, order)` (`internal/dao/photo.go`) honors `Limit`/`Offset`
+    (with a stable `id` tie-breaker so paging can't drop/repeat rows), an `orderBy`, and equipment
+    filters `cameraModel`/`cameraMake`/`lensModel`/`lensMake` (exact match, AND-combined). Built as
+    a small dynamic-predicate helper rather than copying `AlbumPG.SelectPhotos`' two-places-in-sync
+    pattern.
+- **Frontend `getPhotosByCameraModel`** (which hits `/api/photos?cameraModel=`) is no longer dead —
+  it now works for both owner and guest, so the client-side `.filter` on the camera page can go.
+- **Also in the same statement:** #3 (swallowed `List()` error) — obsolete now, `List()` is no
+  longer called here.
 
 ---
 

--- a/internal/dao/photo.go
+++ b/internal/dao/photo.go
@@ -202,6 +202,18 @@ func (dao *PhotoPG) Select(filter PhotoFilter, r Range, order PhotoOrder) ([]*Ph
 		args = append(args, *filter.AlbumId)
 		where = append(where, fmt.Sprintf("id IN (SELECT photoid FROM albumphotos WHERE albumid = $%d)", len(args)))
 	}
+	// eq appends an "img.<col> = $n" predicate for each non-empty equipment
+	// filter, keeping the placeholder index in step with the args slice.
+	eq := func(col, val string) {
+		if val != "" {
+			args = append(args, val)
+			where = append(where, fmt.Sprintf("img.%s = $%d", col, len(args)))
+		}
+	}
+	eq("cameramodel", filter.CameraModel)
+	eq("cameramake", filter.CameraMake)
+	eq("lensmodel", filter.LensModel)
+	eq("lensmake", filter.LensMake)
 	if len(where) > 0 {
 		stmt.WriteString(" WHERE ")
 		stmt.WriteString(strings.Join(where, " AND "))

--- a/internal/dao/photo_select_test.go
+++ b/internal/dao/photo_select_test.go
@@ -153,3 +153,88 @@ func equalIDs(a, b []uuid.UUID) bool {
 	}
 	return true
 }
+
+// sameIDSet compares two id lists ignoring order — filter results have no
+// meaningful order under these tests, only membership.
+func sameIDSet(got []uuid.UUID, want ...uuid.UUID) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	seen := map[uuid.UUID]bool{}
+	for _, id := range got {
+		seen[id] = true
+	}
+	for _, id := range want {
+		if !seen[id] {
+			return false
+		}
+	}
+	return true
+}
+
+func mkEquipPhoto(model, make, lensModel, lensMake string) Photo {
+	p := mkSelectPhoto(model, testEquipTime, testEquipTime)
+	p.CameraMake = make
+	p.LensModel = lensModel
+	p.LensMake = lensMake
+	return p
+}
+
+var testEquipTime = time.Date(2026, 2, 1, 9, 0, 0, 0, time.UTC)
+
+func TestPhotoSelectEquipmentFilters(t *testing.T) {
+	pgdb := openAndCreateTestDb(t)
+	defer deleteAndCloseTestDb(pgdb, t)
+
+	p1 := mkEquipPhoto("Alpha", "Nikon", "50mm", "Nikon")
+	p2 := mkEquipPhoto("Beta", "Nikon", "85mm", "Sigma")
+	p3 := mkEquipPhoto("Alpha", "Canon", "50mm", "Canon")
+	p4 := mkEquipPhoto("Gamma", "Canon", "24mm", "Canon")
+
+	for _, p := range []Photo{p1, p2, p3, p4} {
+		pc := p
+		if err := pgdb.Photo.Add(&pc, nil); err != nil {
+			t.Fatalf("could not add photo %s: %v", p.Title, err)
+		}
+	}
+
+	cases := []struct {
+		name   string
+		filter PhotoFilter
+		want   []uuid.UUID
+	}{
+		{"camera model", PhotoFilter{CameraModel: "Alpha"}, []uuid.UUID{p1.Id, p3.Id}},
+		{"camera make", PhotoFilter{CameraMake: "Nikon"}, []uuid.UUID{p1.Id, p2.Id}},
+		{"lens model", PhotoFilter{LensModel: "50mm"}, []uuid.UUID{p1.Id, p3.Id}},
+		{"lens make", PhotoFilter{LensMake: "Canon"}, []uuid.UUID{p3.Id, p4.Id}},
+		{"model AND make", PhotoFilter{CameraModel: "Alpha", CameraMake: "Nikon"}, []uuid.UUID{p1.Id}},
+		{"model AND lens make", PhotoFilter{CameraModel: "Alpha", LensMake: "Canon"}, []uuid.UUID{p3.Id}},
+		{"no match", PhotoFilter{CameraModel: "Nope"}, nil},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			photos, err := pgdb.Photo.Select(c.filter, Range{}, UploadDate)
+			if err != nil {
+				t.Fatalf("Select failed: %v", err)
+			}
+			if !sameIDSet(idsOf(photos), c.want...) {
+				t.Errorf("expected %v got %v", c.want, idsOf(photos))
+			}
+		})
+	}
+
+	// A filter combined with an album scope — the guest case: filtering within
+	// the photostream. Album holds p1 and p2; only p1 is model Alpha.
+	album, err := pgdb.Album.Add("stream", "desc", "")
+	if err != nil {
+		t.Fatalf("could not add album: %v", err)
+	}
+	if _, err := pgdb.Album.AddPhotos(album.Id, []uuid.UUID{p1.Id, p2.Id}); err != nil {
+		t.Fatalf("could not add photos to album: %v", err)
+	}
+	if photos, err := pgdb.Photo.Select(PhotoFilter{AlbumId: &album.Id, CameraModel: "Alpha"}, Range{}, UploadDate); err != nil {
+		t.Fatalf("Select album+filter failed: %v", err)
+	} else if !sameIDSet(idsOf(photos), p1.Id) {
+		t.Errorf("album+filter expected [p1] got %v", idsOf(photos))
+	}
+}

--- a/internal/dao/types.go
+++ b/internal/dao/types.go
@@ -114,7 +114,11 @@ type Photo struct {
 }
 
 type PhotoFilter struct {
+	// Equipment filters — each is an exact match applied only when non-empty.
 	CameraModel string
+	CameraMake  string
+	LensModel   string
+	LensMake    string
 	// AlbumId scopes the result to members of one album. It is set server-side
 	// (never decoded from a client) and is how the public photo list is limited
 	// to the photostream. nil means no album scope (all photos).

--- a/internal/server/photos.go
+++ b/internal/server/photos.go
@@ -200,15 +200,20 @@ func (s *mserver) handlePhoto(w http.ResponseWriter, r *http.Request) (interface
 	}
 }
 
-// handlePhotos lists photos with optional paging and ordering. It is public
-// (loginInfo): a logged-in owner gets every photo, while a guest gets only the
-// members of the photostream album. That album is a typed user setting; if it is
+// handlePhotos lists photos with optional equipment filters, paging and
+// ordering. It is public (loginInfo): a logged-in owner gets every photo, while
+// a guest gets only the members of the photostream album (an equipment filter is
+// then applied within that stream). That album is a typed user setting; if it is
 // unset, guests get an empty list.
 func (s *mserver) handlePhotos(r *http.Request, loggedIn bool) (interface{}, error) {
 	type request struct {
-		Limit   int
-		Offset  int
-		OrderBy dao.PhotoOrder
+		Limit       int
+		Offset      int
+		OrderBy     dao.PhotoOrder
+		CameraModel string
+		CameraMake  string
+		LensModel   string
+		LensMake    string
 	}
 	var params request
 	if err := decodeRequest(r, &params); err != nil {
@@ -220,7 +225,12 @@ func (s *mserver) handlePhotos(r *http.Request, loggedIn bool) (interface{}, err
 		order = dao.UploadDate
 	}
 
-	var filter dao.PhotoFilter
+	filter := dao.PhotoFilter{
+		CameraModel: params.CameraModel,
+		CameraMake:  params.CameraMake,
+		LensModel:   params.LensModel,
+		LensMake:    params.LensMake,
+	}
 	if !loggedIn {
 		user, err := s.pg.User.Get()
 		if err != nil {


### PR DESCRIPTION
Second of two PRs for server-side photo filtering, and the one that **closes bug #2**. Builds on #34 (public `/api/photos` + `DbVersion` 4).

## What & why

`GET /api/photos` gained a public endpoint, paging, and ordering in #34, but no equipment filters yet. This adds them — the concrete need that started bug #2 (the camera page filtering photos by model, done client-side in both frontends).

Four exact-match filters: `cameraModel`, `cameraMake`, `lensModel`, `lensMake`. Each is applied only when non-empty; multiple filters combine with AND.

## Changes

- **`PhotoFilter`** gains `CameraMake`/`LensModel`/`LensMake` beside the existing `CameraModel`.
- **`PhotoPG.Select`** grows a small `eq` closure that appends an `img.<col> = $n` predicate per non-empty filter, keeping the placeholder index in step with the args slice. Filters layer cleanly on top of the album scope and paging already present — no rewrite.
- **`handlePhotos`** decodes the four params. They apply to both audiences: for a guest they're scoped *within* the photostream (album membership AND filter), so a guest can filter the public stream by camera.

## Notes

- Filters are **exact-match, case-sensitive** (`img.cameramodel = $n`). Correct here: the frontend derives its filter value from the same stored `photo.cameraModel` string, so they always match — and exact match is index-friendly. No fuzzy/`ILIKE` since nothing needs it.
- The frontends' previously-dead `getPhotosByCameraModel` (`/api/photos?cameraModel=`) now works for owner and guest alike, so the camera page can drop its client-side `.filter` and the `isUser` fetch branch. That's a follow-up in each UI repo.

## Docs

- `discovered-bugs.md` — **bug #2 marked fixed**; status table now reads "All eight are resolved."
- `MIGRATION.md` — filter params moved into the live query-param table; the "next release" section flipped to "available" with the UI adoption note.

## Testing

`make ci` green. `TestPhotoSelectEquipmentFilters` (live-Postgres DAO harness): table-driven cases for each of the four filters, two AND-combinations, a no-match, plus the album-scope + filter (guest) case.