### PR TITLE
Add guest v5 schema and DAO foundation

### DIFF
--- a/internal/dao/dao.go
+++ b/internal/dao/dao.go
@@ -9,6 +9,7 @@ import (
 	"github.com/msvens/mimage/metadata"
 	"github.com/msvens/mphotos/internal/config"
 	"go.uber.org/zap"
+	"time"
 )
 
 type AlbumDAO interface {
@@ -61,9 +62,21 @@ type GuestDAO interface {
 	Get(id uuid.UUID) (*Guest, error)
 	GetByEmail(email string) (*Guest, error)
 	Has(id uuid.UUID) bool
+	HasVerified(id uuid.UUID) bool
 	HasByEmail(email string) bool
 	HasByName(name string) bool
 	Update(email string, name string, id uuid.UUID) (*Guest, error)
+	UpdateProfile(id uuid.UUID, name, fullName, description string) (*Guest, error)
+	List() ([]*Guest, error)
+	DeleteUnverifiedBefore(t time.Time) (int64, error)
+}
+
+type GuestCodeDAO interface {
+	Issue(guestId uuid.UUID, purpose, code string, expires time.Time) error
+	FindSignup(code string) (uuid.UUID, bool, error)
+	ConsumeLogin(guestId uuid.UUID, code string) (bool, error)
+	Delete(guestId uuid.UUID, purpose string) error
+	DeleteExpiredBefore(t time.Time) (int64, error)
 }
 
 type ReactionDAO interface {
@@ -108,15 +121,16 @@ type VersionDAO interface {
 }
 
 type PGDB struct {
-	db       *sqlx.DB
-	Album    AlbumDAO
-	Camera   CameraDAO
-	Comment  CommentDAO
-	Guest    GuestDAO
-	Photo    PhotoDAO
-	Reaction ReactionDAO
-	User     UserDAO
-	Version  VersionDAO
+	db        *sqlx.DB
+	Album     AlbumDAO
+	Camera    CameraDAO
+	Comment   CommentDAO
+	Guest     GuestDAO
+	GuestCode GuestCodeDAO
+	Photo     PhotoDAO
+	Reaction  ReactionDAO
+	User      UserDAO
+	Version   VersionDAO
 }
 
 var logger *zap.SugaredLogger
@@ -145,15 +159,16 @@ func NewPGDB() (*PGDB, error) {
 			return nil, err
 		}
 		return &PGDB{
-			db:       db,
-			Album:    NewAlbumPG(db),
-			Camera:   NewCameraPG(db),
-			Comment:  NewCommentPG(db),
-			Guest:    NewGuestPG(db),
-			Photo:    NewPhotoPG(db),
-			Reaction: NewReactionPG(db),
-			User:     NewUserPG(db),
-			Version:  NewVersionPG(db),
+			db:        db,
+			Album:     NewAlbumPG(db),
+			Camera:    NewCameraPG(db),
+			Comment:   NewCommentPG(db),
+			Guest:     NewGuestPG(db),
+			GuestCode: NewGuestCodePG(db),
+			Photo:     NewPhotoPG(db),
+			Reaction:  NewReactionPG(db),
+			User:      NewUserPG(db),
+			Version:   NewVersionPG(db),
 		}, nil
 	}
 }
@@ -176,7 +191,7 @@ func (pgd *PGDB) tableExists(table string) bool {
 }
 
 func (pgd *PGDB) CreateTables() error {
-	if _, err := pgd.db.Exec(schemaV4); err != nil {
+	if _, err := pgd.db.Exec(schemaV5); err != nil {
 		return err
 	} else { //make sure version is correct
 		_, err = pgd.Version.Update()
@@ -188,6 +203,6 @@ func (pgd *PGDB) CreateTables() error {
 }
 
 func (pgd *PGDB) DeleteTables() error {
-	_, err := pgd.db.Exec(deleteSchemaV4)
+	_, err := pgd.db.Exec(deleteSchemaV5)
 	return err
 }

--- a/internal/dao/guest.go
+++ b/internal/dao/guest.go
@@ -28,7 +28,7 @@ func (dao *GuestPG) Add(name, email string) (*Guest, error) {
 }
 func (dao *GuestPG) Delete(id uuid.UUID) error {
 	var cnt int64
-	if res, err := dao.db.Exec("DELETE FROM guests WHERE id = $1", id); err != nil {
+	if res, err := dao.db.Exec("DELETE FROM guest WHERE id = $1", id); err != nil {
 		return err
 	} else {
 		cnt, _ = res.RowsAffected()
@@ -38,6 +38,9 @@ func (dao *GuestPG) Delete(id uuid.UUID) error {
 			return err
 		}
 		if _, err := dao.db.Exec("DELETE from comment WHERE guestId = $1", id); err != nil {
+			return err
+		}
+		if _, err := dao.db.Exec("DELETE from guestcode WHERE guestid = $1", id); err != nil {
 			return err
 		}
 	}
@@ -94,4 +97,49 @@ func (dao *GuestPG) Update(email string, name string, id uuid.UUID) (*Guest, err
 		return nil, err
 	}
 	return dao.Get(id)
+}
+
+// UpdateProfile updates the mutable profile fields. Email is the login identity
+// and is intentionally not updatable here.
+func (dao *GuestPG) UpdateProfile(id uuid.UUID, name, fullName, description string) (*Guest, error) {
+	const stmt = "UPDATE guest SET (name, fullname, description) = ($1, $2, $3) WHERE id = $4"
+	if _, err := dao.db.Exec(stmt, name, fullName, description, id); err != nil {
+		return nil, err
+	}
+	return dao.Get(id)
+}
+
+// List returns all guests, for the owner-facing guest view.
+func (dao *GuestPG) List() ([]*Guest, error) {
+	ret := []*Guest{}
+	err := dao.db.Select(&ret, "SELECT * FROM guest ORDER BY name")
+	return ret, err
+}
+
+// HasVerified reports whether a guest exists AND is verified — the read-path
+// check that gates guest-only routes.
+func (dao *GuestPG) HasVerified(id uuid.UUID) bool {
+	var verified bool
+	if err := dao.db.Get(&verified, "SELECT verified FROM guest WHERE id = $1", id); err != nil {
+		return false
+	}
+	return verified
+}
+
+// DeleteUnverifiedBefore removes guests that never verified and whose signup
+// window (verifytime) is older than t, cascading to their comments/likes/codes.
+// It returns the number of guests removed.
+func (dao *GuestPG) DeleteUnverifiedBefore(t time.Time) (int64, error) {
+	var ids []uuid.UUID
+	if err := dao.db.Select(&ids, "SELECT id FROM guest WHERE verified = false AND verifytime < $1", t); err != nil {
+		return 0, err
+	}
+	var n int64
+	for _, id := range ids {
+		if err := dao.Delete(id); err != nil {
+			return n, err
+		}
+		n++
+	}
+	return n, nil
 }

--- a/internal/dao/guest_test.go
+++ b/internal/dao/guest_test.go
@@ -1,0 +1,162 @@
+package dao
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestGuestProfileAndReap(t *testing.T) {
+	pgdb := openAndCreateTestDb(t)
+	defer deleteAndCloseTestDb(pgdb, t)
+
+	// Add starts a guest unverified.
+	g, err := pgdb.Guest.Add("nick", "nick@example.com")
+	if err != nil {
+		t.Fatalf("could not add guest: %v", err)
+	}
+	if g.Verified {
+		t.Error("new guest should start unverified")
+	}
+	if !pgdb.Guest.HasByEmail("nick@example.com") || !pgdb.Guest.HasByName("nick") {
+		t.Error("guest lookups by email/name should succeed")
+	}
+
+	// HasVerified is false until verified.
+	if pgdb.Guest.HasVerified(g.Id) {
+		t.Error("HasVerified should be false for an unverified guest")
+	}
+	if _, err := pgdb.Guest.Verify(g.Id); err != nil {
+		t.Fatalf("verify failed: %v", err)
+	}
+	if !pgdb.Guest.HasVerified(g.Id) {
+		t.Error("HasVerified should be true after Verify")
+	}
+	if pgdb.Guest.HasVerified(uuid.New()) {
+		t.Error("HasVerified should be false for a nonexistent guest")
+	}
+
+	// UpdateProfile sets the mutable fields; email stays put.
+	upd, err := pgdb.Guest.UpdateProfile(g.Id, "nick2", "Nick Real", "hi there")
+	if err != nil {
+		t.Fatalf("UpdateProfile failed: %v", err)
+	}
+	if upd.Name != "nick2" || upd.FullName != "Nick Real" || upd.Description != "hi there" {
+		t.Errorf("profile not updated: %+v", upd)
+	}
+	if upd.Email != "nick@example.com" {
+		t.Errorf("email should be unchanged, got %q", upd.Email)
+	}
+
+	// List returns the guest.
+	if list, err := pgdb.Guest.List(); err != nil {
+		t.Fatalf("List failed: %v", err)
+	} else if len(list) != 1 || list[0].Id != g.Id {
+		t.Errorf("expected [%v], got %+v", g.Id, list)
+	}
+
+	// Reap: a stale unverified guest is removed; verified/fresh ones survive.
+	stale, _ := pgdb.Guest.Add("stale", "stale@example.com")
+	if _, err := pgdb.db.Exec("UPDATE guest SET verifytime = $1 WHERE id = $2",
+		time.Now().Add(-48*time.Hour), stale.Id); err != nil {
+		t.Fatalf("could not age stale guest: %v", err)
+	}
+	n, err := pgdb.Guest.DeleteUnverifiedBefore(time.Now().Add(-24 * time.Hour))
+	if err != nil {
+		t.Fatalf("reap failed: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("expected 1 reaped, got %d", n)
+	}
+	if pgdb.Guest.Has(stale.Id) {
+		t.Error("stale unverified guest should be gone")
+	}
+	if !pgdb.Guest.Has(g.Id) {
+		t.Error("verified guest should survive the reap")
+	}
+}
+
+func TestGuestDeleteCascade(t *testing.T) {
+	pgdb := openAndCreateTestDb(t)
+	defer deleteAndCloseTestDb(pgdb, t)
+
+	g, _ := pgdb.Guest.Add("casc", "casc@example.com")
+	photoId := uuid.New()
+	if err := pgdb.Reaction.Add(&Reaction{GuestId: g.Id, PhotoId: photoId, Kind: "like"}); err != nil {
+		t.Fatalf("could not add reaction: %v", err)
+	}
+	if err := pgdb.GuestCode.Issue(g.Id, GuestCodeSignup, "tok", time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("could not issue code: %v", err)
+	}
+
+	if err := pgdb.Guest.Delete(g.Id); err != nil {
+		t.Fatalf("delete failed: %v", err)
+	}
+	if pgdb.Guest.Has(g.Id) {
+		t.Error("guest should be deleted")
+	}
+	if pgdb.Reaction.Has(g.Id, photoId) {
+		t.Error("reaction should be cascaded away")
+	}
+	if _, ok, _ := pgdb.GuestCode.FindSignup("tok"); ok {
+		t.Error("guest code should be cascaded away")
+	}
+}
+
+func TestGuestCodes(t *testing.T) {
+	pgdb := openAndCreateTestDb(t)
+	defer deleteAndCloseTestDb(pgdb, t)
+
+	g, _ := pgdb.Guest.Add("codeguest", "code@example.com")
+
+	// Signup token: found while valid, resolves to the guest.
+	if err := pgdb.GuestCode.Issue(g.Id, GuestCodeSignup, "signup-token", time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("issue signup failed: %v", err)
+	}
+	if id, ok, _ := pgdb.GuestCode.FindSignup("signup-token"); !ok || id != g.Id {
+		t.Errorf("FindSignup should resolve to guest, got ok=%v id=%v", ok, id)
+	}
+	if _, ok, _ := pgdb.GuestCode.FindSignup("wrong-token"); ok {
+		t.Error("FindSignup should miss on a wrong token")
+	}
+
+	// Login code: single-use consume.
+	if err := pgdb.GuestCode.Issue(g.Id, GuestCodeLogin, "654321", time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("issue login failed: %v", err)
+	}
+	if ok, _ := pgdb.GuestCode.ConsumeLogin(g.Id, "000000"); ok {
+		t.Error("consume should fail on wrong code")
+	}
+	if ok, _ := pgdb.GuestCode.ConsumeLogin(g.Id, "654321"); !ok {
+		t.Error("consume should succeed on correct code")
+	}
+	if ok, _ := pgdb.GuestCode.ConsumeLogin(g.Id, "654321"); ok {
+		t.Error("consume should fail the second time (single use)")
+	}
+
+	// Issue overwrites the previous code for (guest, purpose).
+	_ = pgdb.GuestCode.Issue(g.Id, GuestCodeSignup, "first", time.Now().Add(time.Hour))
+	_ = pgdb.GuestCode.Issue(g.Id, GuestCodeSignup, "second", time.Now().Add(time.Hour))
+	if _, ok, _ := pgdb.GuestCode.FindSignup("first"); ok {
+		t.Error("old signup token should be overwritten")
+	}
+	if _, ok, _ := pgdb.GuestCode.FindSignup("second"); !ok {
+		t.Error("latest signup token should be active")
+	}
+
+	// Expiry: an expired code is neither found nor consumable, and is purged.
+	_ = pgdb.GuestCode.Issue(g.Id, GuestCodeLogin, "999999", time.Now().Add(-time.Minute))
+	if ok, _ := pgdb.GuestCode.ConsumeLogin(g.Id, "999999"); ok {
+		t.Error("expired login code should not consume")
+	}
+	_ = pgdb.GuestCode.Issue(g.Id, GuestCodeSignup, "expired-tok", time.Now().Add(-time.Minute))
+	if _, ok, _ := pgdb.GuestCode.FindSignup("expired-tok"); ok {
+		t.Error("expired signup token should not be found")
+	}
+	if n, err := pgdb.GuestCode.DeleteExpiredBefore(time.Now()); err != nil {
+		t.Fatalf("DeleteExpiredBefore failed: %v", err)
+	} else if n < 1 {
+		t.Errorf("expected to purge at least 1 expired code, got %d", n)
+	}
+}

--- a/internal/dao/guestcode.go
+++ b/internal/dao/guestcode.go
@@ -1,0 +1,77 @@
+package dao
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+)
+
+// Guest code purposes.
+const (
+	GuestCodeSignup = "signup"
+	GuestCodeLogin  = "login"
+)
+
+// GuestCodePG stores short-lived one-time codes for guest signup verification
+// (a link token) and login (a typed numeric code). At most one active code
+// exists per (guest, purpose); issuing again overwrites the previous one.
+type GuestCodePG struct {
+	db *sqlx.DB
+}
+
+func NewGuestCodePG(db *sqlx.DB) *GuestCodePG {
+	return &GuestCodePG{db}
+}
+
+// Issue stores (or replaces) the code for a (guest, purpose) with an expiry.
+func (dao *GuestCodePG) Issue(guestId uuid.UUID, purpose, code string, expires time.Time) error {
+	const stmt = `INSERT INTO guestcode (guestid, purpose, code, expires) VALUES ($1, $2, $3, $4)
+		ON CONFLICT (guestid, purpose) DO UPDATE SET code = EXCLUDED.code, expires = EXCLUDED.expires`
+	_, err := dao.db.Exec(stmt, guestId, purpose, code, expires)
+	return err
+}
+
+// FindSignup resolves a signup token to its guest, provided the token is
+// unexpired. The token is unguessable (32 random bytes), so a lookup by code
+// alone is safe. Returns (id, true, nil) on a valid match.
+func (dao *GuestCodePG) FindSignup(code string) (uuid.UUID, bool, error) {
+	var id uuid.UUID
+	err := dao.db.Get(&id,
+		"SELECT guestid FROM guestcode WHERE purpose = $1 AND code = $2 AND expires > $3",
+		GuestCodeSignup, code, time.Now())
+	if err != nil {
+		return uuid.Nil, false, nil
+	}
+	return id, true, nil
+}
+
+// ConsumeLogin verifies a login code for a guest and, on success, deletes it
+// (single use). Returns true only when the code matched and was unexpired.
+func (dao *GuestCodePG) ConsumeLogin(guestId uuid.UUID, code string) (bool, error) {
+	res, err := dao.db.Exec(
+		"DELETE FROM guestcode WHERE guestid = $1 AND purpose = $2 AND code = $3 AND expires > $4",
+		guestId, GuestCodeLogin, code, time.Now())
+	if err != nil {
+		return false, err
+	}
+	n, _ := res.RowsAffected()
+	return n > 0, nil
+}
+
+// Delete removes the code for a (guest, purpose), e.g. a signup token once the
+// guest is verified.
+func (dao *GuestCodePG) Delete(guestId uuid.UUID, purpose string) error {
+	_, err := dao.db.Exec("DELETE FROM guestcode WHERE guestid = $1 AND purpose = $2", guestId, purpose)
+	return err
+}
+
+// DeleteExpiredBefore purges codes whose expiry is older than t.
+func (dao *GuestCodePG) DeleteExpiredBefore(t time.Time) (int64, error) {
+	res, err := dao.db.Exec("DELETE FROM guestcode WHERE expires < $1", t)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}

--- a/internal/dao/migrate.go
+++ b/internal/dao/migrate.go
@@ -1,7 +1,6 @@
 package dao
 
 import (
-	"encoding/json"
 	"fmt"
 )
 
@@ -30,7 +29,7 @@ func UpgradeDb() error {
 			logger.Info("Database is up to date")
 			return nil
 		} else if canUpgradeDb(pgdb) {
-			return upgradeToV4(pgdb)
+			return upgradeToV5(pgdb)
 		} else {
 			return fmt.Errorf("cannot upgrade database, wrong current version")
 		}
@@ -45,11 +44,23 @@ func UpgradeDb() error {
 	return nil
 }
 
-func upgradeToV4(pgdb *PGDB) error {
+func upgradeToV5(pgdb *PGDB) error {
 	logger.Infow("Upgrading Db to Version", "version", DbVersion)
 
-	if _, err := pgdb.db.Exec(schemaV3toV4); err != nil {
+	if _, err := pgdb.db.Exec(schemaV4toV5); err != nil {
 		return err
+	}
+
+	// Grandfather every existing guest to verified=true. Under the old flow the
+	// verified flag was cosmetic and never enforced, so legacy guests were fully
+	// active regardless. Without this the new verified-only login would lock them
+	// out and the reaper would delete them (and their comments/likes) on first run.
+	res, err := pgdb.db.Exec("UPDATE guest SET verified = true WHERE verified = false")
+	if err != nil {
+		return err
+	}
+	if n, _ := res.RowsAffected(); n > 0 {
+		logger.Infow("grandfathered existing guests to verified", "count", n)
 	}
 
 	logger.Info("Db Updated. Change Version Info")
@@ -57,26 +68,6 @@ func upgradeToV4(pgdb *PGDB) error {
 		return err
 	} else {
 		logger.Infow("Updated Db to version", "version", v.VersionId)
-	}
-
-	// Seed the new typed column once from the client config blob — the only place
-	// the photostream album id lived before this version. This is the single
-	// appropriate spot to read that blob; the running server never does.
-	var config string
-	if err := pgdb.db.Get(&config, "SELECT config FROM usert LIMIT 1"); err != nil {
-		logger.Warnw("could not read user config while seeding photostream id; leaving it unset", "error", err)
-		return nil
-	}
-	var conf map[string]interface{}
-	if err := json.Unmarshal([]byte(config), &conf); err != nil {
-		logger.Warnw("could not parse user config while seeding photostream id; leaving it unset", "error", err)
-		return nil
-	}
-	if id, ok := conf["photoStreamAlbumId"].(string); ok && id != "" {
-		if _, err := pgdb.db.Exec("UPDATE usert SET photostreamalbumid = $1", id); err != nil {
-			return err
-		}
-		logger.Infow("seeded photostream album id from config", "id", id)
 	}
 	return nil
 }

--- a/internal/dao/migrate_test.go
+++ b/internal/dao/migrate_test.go
@@ -2,36 +2,41 @@ package dao
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 )
 
-// TestUpgradeToV4Seed rewinds a freshly created (v4) database to the v3 shape —
-// no photostreamalbumid column, version 3, the album id living only in the config
-// blob — then runs upgradeToV4 and asserts the column is seeded from that blob.
-// The drop/recreate harness only ever creates the latest schema, so this is the
-// only coverage of the migration seed path.
-func TestUpgradeToV4Seed(t *testing.T) {
+// TestUpgradeToV5 rewinds a freshly created (v5) database to the v4 shape — no
+// fullname/description columns, no guestcode table, version 4, with an
+// unverified legacy guest — then runs upgradeToV5 and asserts the schema is
+// extended and every existing guest is grandfathered to verified=true. The
+// drop/recreate harness only ever creates the latest schema, so this is the only
+// coverage of the migration path.
+func TestUpgradeToV5(t *testing.T) {
 	pgdb := openAndCreateTestDb(t)
 	defer deleteAndCloseTestDb(pgdb, t)
 
-	streamID := uuid.New().String()
+	// Rewind to the v4 guest shape and insert a legacy, unverified guest.
+	for _, stmt := range []string{
+		"ALTER TABLE guest DROP COLUMN fullname",
+		"ALTER TABLE guest DROP COLUMN description",
+		"DROP TABLE IF EXISTS guestcode",
+		"UPDATE version SET versionId = 4",
+	} {
+		if _, err := pgdb.db.Exec(stmt); err != nil {
+			t.Fatalf("rewind step %q failed: %v", stmt, err)
+		}
+	}
+	gid := uuid.New()
+	if _, err := pgdb.db.Exec(
+		"INSERT INTO guest (id, name, email, verified, verifytime) VALUES ($1,$2,$3,$4,$5)",
+		gid, "legacy", "legacy@example.com", false, time.Now()); err != nil {
+		t.Fatalf("could not insert legacy guest: %v", err)
+	}
 
-	// Rewind to v3: drop the new column, mark the db version 3, and stash the
-	// photostream id in the config blob the way the old clients did.
-	if _, err := pgdb.db.Exec("ALTER TABLE usert DROP COLUMN photostreamalbumid"); err != nil {
-		t.Fatalf("could not drop column to simulate v3: %v", err)
-	}
-	if _, err := pgdb.db.Exec("UPDATE version SET versionId = 3"); err != nil {
-		t.Fatalf("could not set version to 3: %v", err)
-	}
-	if _, err := pgdb.db.Exec(`UPDATE usert SET config = $1`,
-		`{"photoStreamAlbumId":"`+streamID+`","photoGridCols":3}`); err != nil {
-		t.Fatalf("could not seed config blob: %v", err)
-	}
-
-	if err := upgradeToV4(pgdb); err != nil {
-		t.Fatalf("upgradeToV4 failed: %v", err)
+	if err := upgradeToV5(pgdb); err != nil {
+		t.Fatalf("upgradeToV5 failed: %v", err)
 	}
 
 	// Version bumped.
@@ -41,41 +46,20 @@ func TestUpgradeToV4Seed(t *testing.T) {
 		t.Errorf("expected version %d got %d", DbVersion, v.VersionId)
 	}
 
-	// Column exists and was seeded from the blob.
-	user, err := pgdb.User.Get()
+	// Legacy guest preserved and grandfathered to verified, with empty new fields.
+	g, err := pgdb.Guest.Get(gid)
 	if err != nil {
-		t.Fatalf("could not read user after upgrade: %v", err)
+		t.Fatalf("legacy guest not preserved: %v", err)
 	}
-	if user.PhotoStreamAlbumId != streamID {
-		t.Errorf("expected seeded photoStreamAlbumId %q got %q", streamID, user.PhotoStreamAlbumId)
+	if !g.Verified {
+		t.Error("expected legacy guest to be grandfathered to verified=true")
 	}
-}
-
-// TestUpgradeToV4NoSeed verifies the migration is resilient when the config blob
-// has no photostream id: the column is added and left empty, not errored.
-func TestUpgradeToV4NoSeed(t *testing.T) {
-	pgdb := openAndCreateTestDb(t)
-	defer deleteAndCloseTestDb(pgdb, t)
-
-	if _, err := pgdb.db.Exec("ALTER TABLE usert DROP COLUMN photostreamalbumid"); err != nil {
-		t.Fatalf("could not drop column to simulate v3: %v", err)
-	}
-	if _, err := pgdb.db.Exec("UPDATE version SET versionId = 3"); err != nil {
-		t.Fatalf("could not set version to 3: %v", err)
-	}
-	if _, err := pgdb.db.Exec(`UPDATE usert SET config = '{}'`); err != nil {
-		t.Fatalf("could not reset config blob: %v", err)
+	if g.FullName != "" || g.Description != "" {
+		t.Errorf("expected empty new profile fields, got fullName=%q description=%q", g.FullName, g.Description)
 	}
 
-	if err := upgradeToV4(pgdb); err != nil {
-		t.Fatalf("upgradeToV4 failed: %v", err)
-	}
-
-	user, err := pgdb.User.Get()
-	if err != nil {
-		t.Fatalf("could not read user after upgrade: %v", err)
-	}
-	if user.PhotoStreamAlbumId != "" {
-		t.Errorf("expected empty photoStreamAlbumId, got %q", user.PhotoStreamAlbumId)
+	// guestcode table exists and is usable after the upgrade.
+	if err := pgdb.GuestCode.Issue(gid, GuestCodeLogin, "123456", time.Now().Add(time.Minute)); err != nil {
+		t.Errorf("guestcode table not usable after upgrade: %v", err)
 	}
 }

--- a/internal/dao/schema.go
+++ b/internal/dao/schema.go
@@ -1,11 +1,19 @@
 package dao
 
-// schemaV3toV4 adds the photostreamalbumid column to usert. It is seeded from
-// the existing config blob by upgradeToV4 (schema.go can't read the old value).
-const schemaV3toV4 = `
-	ALTER TABLE usert ADD COLUMN photostreamalbumid TEXT NOT NULL DEFAULT '';
+// schemaV4toV5 enriches the guest profile and adds the one-time code store.
+// upgradeToV5 also grandfathers existing guests to verified=true (see migrate.go).
+const schemaV4toV5 = `
+	ALTER TABLE guest ADD COLUMN fullname TEXT NOT NULL DEFAULT '';
+	ALTER TABLE guest ADD COLUMN description TEXT NOT NULL DEFAULT '';
+	CREATE TABLE IF NOT EXISTS guestcode (
+		guestid UUID NOT NULL,
+		purpose TEXT NOT NULL,
+		code    TEXT NOT NULL,
+		expires TIMESTAMP NOT NULL,
+		PRIMARY KEY (guestid, purpose)
+	);
 `
-const schemaV4 = `
+const schemaV5 = `
 CREATE TABLE IF NOT EXISTS album (
 	Id UUID,
 	name TEXT,
@@ -81,10 +89,20 @@ CREATE TABLE IF NOT EXISTS guest (
 	id UUID PRIMARY KEY,
 	name TEXT NOT NULL,
 	email TEXT NOT NULL,
+	fullname TEXT NOT NULL DEFAULT '',
+	description TEXT NOT NULL DEFAULT '',
 	verified BOOLEAN NOT NULL,
 	verifytime TIMESTAMP NOT NULL,
 	CONSTRAINT guest_email UNIQUE (email),
 	CONSTRAINT guest_name UNIQUE (name)
+);
+
+CREATE TABLE IF NOT EXISTS guestcode (
+	guestid UUID NOT NULL,
+	purpose TEXT NOT NULL,
+	code    TEXT NOT NULL,
+	expires TIMESTAMP NOT NULL,
+	PRIMARY KEY (guestid, purpose)
 );
 
 CREATE TABLE IF NOT EXISTS reaction (
@@ -143,13 +161,14 @@ INSERT INTO version (versionId,description) VALUES (0,'no version set') ON CONFL
 INSERT INTO usert (id, name, bio, pic, driveFolderId, driveFolderName, config) VALUES (23657, '', '', '', '','','{}') ON CONFLICT (id) DO NOTHING;
 `
 
-const deleteSchemaV4 = `
+const deleteSchemaV5 = `
 DROP TABLE IF EXISTS album;
 DROP TABLE IF EXISTS albumphotos;
 DROP TABLE IF EXISTS camera;
 DROP TABLE IF EXISTS comment;
 DROP TABLE IF EXISTS exifdata;
 DROP TABLE IF EXISTS guest;
+DROP TABLE IF EXISTS guestcode;
 DROP TABLE IF EXISTS reaction;
 DROP TABLE IF EXISTS img;
 DROP TABLE IF EXISTS usert;

--- a/internal/dao/types.go
+++ b/internal/dao/types.go
@@ -6,8 +6,8 @@ import (
 	"time"
 )
 
-const DbVersion = 4
-const DbDescription = "Version 4 promotes the photo stream album id to a typed user column"
+const DbVersion = 5
+const DbDescription = "Version 5 enriches the guest profile and adds the one-time code store"
 
 type Album struct {
 	Id          uuid.UUID  `json:"id"`
@@ -69,11 +69,13 @@ type Exif struct {
 }
 
 type Guest struct {
-	Id         uuid.UUID `json:"-"`
-	Email      string    `json:"email"`
-	Name       string    `json:"name"`
-	Verified   bool      `json:"verified"`
-	VerifyTime time.Time `json:"verifyTime"`
+	Id          uuid.UUID `json:"-"`
+	Email       string    `json:"email"`
+	Name        string    `json:"name"`
+	FullName    string    `json:"fullName"`
+	Description string    `json:"description"`
+	Verified    bool      `json:"verified"`
+	VerifyTime  time.Time `json:"verifyTime"`
 }
 
 // GuestReaction is the public view of a reaction. It deliberately carries no


### PR DESCRIPTION
First of ~3 PRs redesigning the guest auth flow (see plan). This one is **pure data-layer foundation — no handler changes, so nothing behaves differently yet.** The live guest flow is untouched until PR 2.

## Why

The guest flow is being hardened (cookie TTL, email→OTP login, expiring signup verification with reaping, richer profile). All of that needs a place to store one-time codes and two new profile fields — this PR lays that groundwork.

## Schema — `DbVersion` 4 → 5

- `guest` gains `fullname` + `description` (`TEXT NOT NULL DEFAULT ''`).
- New `guestcode` table: short-lived one-time codes keyed by `(guestid, purpose)` — `signup` (a link token) and `login` (a typed numeric code), each with an expiry.
- `upgradeToV5` runs those DDLs **and grandfathers every existing guest to `verified=true`**. This is the critical data-preservation step: under the old flow `verified` was cosmetic and never enforced, so legacy guests were fully active regardless of the flag. Without grandfathering, the coming verified-only login would lock them out **and** the reaper (deletes unverified past a TTL, cascading to comments/likes) would delete them and their data on first run. This keeps every guest, lets them all log in via email→code, and keeps the reaper off them.
- Follows the established single-step migration recipe (replaced `upgradeToV4`, renamed `schemaV5`/`deleteSchemaV5`, repointed the dispatch).

## DAO

- **New `GuestCodePG`** (`guestcode.go`): `Issue` (upsert, latest-wins), `FindSignup` (token → guest, unexpired), `ConsumeLogin` (single-use verify+delete), `Delete`, `DeleteExpiredBefore`.
- **`GuestPG`**: `UpdateProfile` (email stays immutable — it's the login identity), `List` (owner view), `HasVerified` (the new read-path gate), `DeleteUnverifiedBefore` (reaper). Fixed the latent `Delete` bug that targeted a nonexistent `guests` (plural) table; it now also cascades `guestcode` cleanup.
- `Guest` struct gains `FullName`/`Description`; wired `GuestCode` into `PGDB` + interfaces.

## Data preservation

Existing guest rows and their comments/likes are untouched (additive columns); all existing guests become `verified=true`; existing cookies keep working (same keys, same 30-day codec window). Deploy needs `db upgrade` (server doesn't auto-migrate) — same as prior versions.

## Testing

`make ci` green. New DAO tests (live-Postgres harness): `TestUpgradeToV5` (grandfathering + data preservation + guestcode usable), plus code lifecycle (single-use, overwrite, expiry), profile update, `HasVerified`, reap (stale removed / verified survives), and delete-cascade.