### PR TITLE
Rework guest auth to email codes with a real cookie TTL

### DIFF
--- a/config_example.yaml
+++ b/config_example.yaml
@@ -3,6 +3,7 @@ server:
   port: 8050
   host: localhost
   verifyUrl: http://localhost:8050/api/guest/verify #link to verify in verification email
+  secureCookies: true #set the Secure flag on session cookies; true in production (HTTPS), false for local http dev
 
 service:
   root: .server #default

--- a/config_test.yaml
+++ b/config_test.yaml
@@ -3,6 +3,7 @@ server:
   port: 8050
   host: localhost
   verifyUrl: http://localhost:8050/api/guest/verify
+  secureCookies: false
 
 service:
   root: .server

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -146,6 +146,12 @@ func VerifyUrl() string {
 	return viper.GetString("server.verifyUrl")
 }
 
+// SecureCookies reports whether session cookies should carry the Secure flag.
+// True in production (HTTPS behind nginx); false for local dev over http.
+func SecureCookies() bool {
+	return viper.GetBool("server.secureCookies")
+}
+
 func ServerPrefix() string {
 	return viper.GetString("server.prefix")
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -40,6 +40,9 @@ func TestConfigFile(t *testing.T) {
 	if VerifyUrl() != "http://localhost:8050/api/guest/verify" {
 		t.Errorf("expected http://localhost:8050/api/guest/verify got #{VerifyUrl()}")
 	}
+	if !SecureCookies() {
+		t.Errorf("expected secureCookies true got %v", SecureCookies())
+	}
 
 	//session config:
 	if SessionCookieName() != "server-session" {

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -9,6 +9,7 @@ import (
 	"github.com/msvens/mphotos/internal/config"
 	"go.uber.org/zap"
 	"golang.org/x/oauth2"
+	"math/big"
 	"net/http"
 	"net/url"
 	"os"
@@ -312,6 +313,16 @@ func generateOAuthState() (string, error) {
 		return "", err
 	}
 	return base64.URLEncoding.EncodeToString(b), nil
+}
+
+// generateLoginCode returns a 6-digit numeric code from crypto/rand, suitable
+// for typing into a login form.
+func generateLoginCode() (string, error) {
+	n, err := rand.Int(rand.Reader, big.NewInt(1000000))
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%06d", n.Int64()), nil
 }
 
 func fetchGoogleUserinfo(ctx context.Context, token *oauth2.Token) (string, bool, error) {

--- a/internal/server/guest.go
+++ b/internal/server/guest.go
@@ -17,8 +17,16 @@ type SessionGuest struct {
 }
 
 const (
-	Session_Year  int = 60 * 60 * 24 * 365
 	Session_Month int = 60 * 60 * 24 * 30
+
+	// guestCookieMaxAge is how long a guest stays signed in before the cookie
+	// expires and an email one-time-code login is required again.
+	guestCookieMaxAge = Session_Month
+	// signupTokenMaxAge is the window to click the emailed verification link, and
+	// also the age past which an unverified guest is reaped.
+	signupTokenMaxAge = 60 * 60 * 24 // 24 hours
+	// loginCodeMaxAge is the lifetime of an emailed numeric login code.
+	loginCodeMaxAge = 15 * 60 // 15 minutes
 )
 
 var emptyuuid = uuid.UUID{}
@@ -29,7 +37,15 @@ type WelcomeEmail struct {
 	Name      string
 }
 
-var templates = template.Must(template.ParseFiles("tmpl/welcome-email.html"))
+type LoginCodeEmail struct {
+	Name string
+	Code string
+}
+
+var templates = template.Must(template.ParseFiles(
+	"tmpl/welcome-email.html",
+	"tmpl/login-code-email.html",
+))
 
 func sessionGuest(session *sessions.Session) (SessionGuest, bool) {
 	val := session.Values["guest"]
@@ -53,10 +69,10 @@ func guestUUID(w http.ResponseWriter, r *http.Request, s *mserver) (uuid.UUID, e
 		s.l.Warnw("could not parse session guest")
 		return s.clearGuestCookie(w, r, session)
 	} else {
-		if s.pg.Guest.Has(uuid) {
+		if s.pg.Guest.HasVerified(uuid) {
 			return uuid, nil
 		} else {
-			s.l.Debugw("guest not found in db")
+			s.l.Debugw("guest not found or not verified")
 			return s.clearGuestCookie(w, r, session)
 		}
 	}
@@ -155,26 +171,33 @@ func (s *mserver) handlePhotoLikes(r *http.Request, loggedIn bool) (interface{},
 	}
 }
 
+// handleVerifyGuest activates a guest from the one-time signup token in their
+// verification link, then signs them in. The token (unlike the old scheme, which
+// reused the guest's own uuid) is unguessable, single-use, and expires.
 func (s *mserver) handleVerifyGuest(w http.ResponseWriter, r *http.Request) (interface{}, error) {
 	type request struct {
 		Code string
 	}
 	var params request
-	var err error
-	var id uuid.UUID
-	if err = decodeRequest(r, &params); err != nil {
+	if err := decodeRequest(r, &params); err != nil {
 		return nil, err
 	}
-	if id, err = uuid.Parse(params.Code); err != nil {
-		return nil, BadRequestError("could not parse guest id: " + err.Error())
+	if params.Code == "" {
+		return nil, BadRequestError("missing verification code")
 	}
-	if ver, err := s.pg.Guest.Verify(id); err != nil {
+	id, ok, err := s.pg.GuestCode.FindSignup(params.Code)
+	if err != nil {
 		return nil, err
-	} else if ver.Verified {
-		return ver, s.saveGuestCookie(w, r, id, Session_Year)
-	} else {
-		return ver, nil
 	}
+	if !ok {
+		return nil, BadRequestError("invalid or expired verification link")
+	}
+	ver, err := s.pg.Guest.Verify(id)
+	if err != nil {
+		return nil, err
+	}
+	_ = s.pg.GuestCode.Delete(id, dao.GuestCodeSignup)
+	return ver, s.saveGuestCookie(w, r, id, guestCookieMaxAge)
 }
 
 func (s *mserver) handleIsGuest(w http.ResponseWriter, r *http.Request) (interface{}, error) {
@@ -210,78 +233,183 @@ func (s *mserver) handleGuestLikePhoto(r *http.Request, guestId uuid.UUID) (inte
 	}
 }
 
-func (s *mserver) handleCreateGuest(w http.ResponseWriter, r *http.Request) (interface{}, error) {
-
-	sendEmail := func(g *dao.Guest) error {
-		var b strings.Builder
-		we := WelcomeEmail{Name: g.Name, Code: g.Id.String(), VerifyUrl: config.VerifyUrl()}
-		if err := templates.ExecuteTemplate(&b, "welcome-email.html", we); err != nil {
-			return err
-		}
-		_, err := s.ms.SendHtmlMessage(g.Email, "Mellowtech Guest Verification", b.String())
+// sendSignupEmail issues a fresh single-use signup token, stores it, and emails
+// the verification link.
+func (s *mserver) sendSignupEmail(guestId uuid.UUID, name, email string) error {
+	if s.ms == nil {
+		return InternalError("email service not configured")
+	}
+	token, err := generateOAuthState()
+	if err != nil {
+		return InternalError(err.Error())
+	}
+	expires := time.Now().Add(time.Duration(signupTokenMaxAge) * time.Second)
+	if err := s.pg.GuestCode.Issue(guestId, dao.GuestCodeSignup, token, expires); err != nil {
 		return err
 	}
-
-	type request struct {
-		Email string
-		Name  string
+	var b strings.Builder
+	we := WelcomeEmail{Name: name, Code: token, VerifyUrl: config.VerifyUrl()}
+	if err := templates.ExecuteTemplate(&b, "welcome-email.html", we); err != nil {
+		return err
 	}
+	_, err = s.ms.SendHtmlMessage(email, "Mellowtech Guest Verification", b.String())
+	return err
+}
 
+// handleCreateGuest registers a guest. The guest is created pending and is only
+// activated (and given a cookie) once they click the emailed verification link —
+// no cookie is issued here.
+func (s *mserver) handleCreateGuest(w http.ResponseWriter, r *http.Request) (interface{}, error) {
+	type request struct {
+		Email       string
+		Name        string
+		FullName    string
+		Description string
+	}
 	var params request
-
 	if err := decodeRequest(r, &params); err != nil {
 		return nil, err
 	}
-	if s.pg.Guest.HasByEmail(params.Email) {
-		s.l.Debugw("guest already exists send a new verify email", "email", params.Email)
-		guest, _ := s.pg.Guest.GetByEmail(params.Email)
+	if strings.TrimSpace(params.Email) == "" || strings.TrimSpace(params.Name) == "" {
+		return nil, BadRequestError("name and email are required")
+	}
 
-		if guest.Name != params.Name {
-			return nil, UnauthorizedError("name does not match provided email")
-		}
-		//here we should send a notification email...not a verify email
-		if err := sendEmail(guest); err != nil {
+	// Returning email: verified guests should log in; unverified (never clicked)
+	// guests get their pending signup refreshed and a new link.
+	if s.pg.Guest.HasByEmail(params.Email) {
+		existing, err := s.pg.Guest.GetByEmail(params.Email)
+		if err != nil {
 			return nil, err
 		}
-		return guest, s.saveGuestCookie(w, r, guest.Id, Session_Year)
+		if existing.Verified {
+			return nil, BadRequestError("an account with this email already exists — please log in")
+		}
+		if _, err := s.pg.Guest.UpdateProfile(existing.Id, params.Name, params.FullName, params.Description); err != nil {
+			return nil, err
+		}
+		if err := s.sendSignupEmail(existing.Id, params.Name, params.Email); err != nil {
+			return nil, err
+		}
+		return existing, nil
 	}
-	//user email not found try to create new user
+
 	if s.pg.Guest.HasByName(params.Name) {
-		return nil, UnauthorizedError("name already exists")
+		return nil, BadRequestError("name already taken")
 	}
-	//add new guest
-	if guest, err := s.pg.Guest.Add(params.Name, params.Email); err != nil {
+	guest, err := s.pg.Guest.Add(params.Name, params.Email)
+	if err != nil {
 		return nil, err
-	} else {
-		if err := sendEmail(guest); err != nil {
+	}
+	if params.FullName != "" || params.Description != "" {
+		if _, err := s.pg.Guest.UpdateProfile(guest.Id, params.Name, params.FullName, params.Description); err != nil {
 			_ = s.pg.Guest.Delete(guest.Id)
 			return nil, err
 		}
-		return guest, s.saveGuestCookie(w, r, guest.Id, Session_Year)
 	}
-
+	if err := s.sendSignupEmail(guest.Id, params.Name, params.Email); err != nil {
+		_ = s.pg.Guest.Delete(guest.Id)
+		return nil, err
+	}
+	return guest, nil
 }
 
-func (s *mserver) handleUpdateGuest(r *http.Request, guestId uuid.UUID) (interface{}, error) {
-
+// handleGuestLogin starts an email one-time-code login: a verified guest with
+// this email is emailed a numeric code. The response is deliberately neutral so
+// it never reveals whether an email is registered.
+func (s *mserver) handleGuestLogin(w http.ResponseWriter, r *http.Request) (interface{}, error) {
 	type request struct {
 		Email string
-		Name  string
 	}
-
 	var params request
-
 	if err := decodeRequest(r, &params); err != nil {
 		return nil, err
 	}
+	neutral := map[string]string{"message": "if that email is registered, a login code has been sent"}
+	if strings.TrimSpace(params.Email) == "" || !s.pg.Guest.HasByEmail(params.Email) {
+		return neutral, nil
+	}
+	guest, err := s.pg.Guest.GetByEmail(params.Email)
+	if err != nil || !guest.Verified {
+		return neutral, nil
+	}
+	if s.ms == nil {
+		return nil, InternalError("email service not configured")
+	}
+	code, err := generateLoginCode()
+	if err != nil {
+		return nil, InternalError(err.Error())
+	}
+	expires := time.Now().Add(time.Duration(loginCodeMaxAge) * time.Second)
+	if err := s.pg.GuestCode.Issue(guest.Id, dao.GuestCodeLogin, code, expires); err != nil {
+		return nil, err
+	}
+	var b strings.Builder
+	if err := templates.ExecuteTemplate(&b, "login-code-email.html", LoginCodeEmail{Name: guest.Name, Code: code}); err != nil {
+		return nil, err
+	}
+	if _, err := s.ms.SendHtmlMessage(guest.Email, "Your Mellowtech Photos login code", b.String()); err != nil {
+		return nil, err
+	}
+	return neutral, nil
+}
 
+// handleGuestLoginVerify consumes an email login code and signs the guest in.
+func (s *mserver) handleGuestLoginVerify(w http.ResponseWriter, r *http.Request) (interface{}, error) {
+	type request struct {
+		Email string
+		Code  string
+	}
+	var params request
+	if err := decodeRequest(r, &params); err != nil {
+		return nil, err
+	}
+	guest, err := s.pg.Guest.GetByEmail(params.Email)
+	if err != nil {
+		return nil, UnauthorizedError("invalid email or code")
+	}
+	ok, err := s.pg.GuestCode.ConsumeLogin(guest.Id, params.Code)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, UnauthorizedError("invalid email or code")
+	}
+	return guest, s.saveGuestCookie(w, r, guest.Id, guestCookieMaxAge)
+}
+
+// reapGuests periodically removes guests who never verified within the signup
+// window (cascading their comments/likes) and purges expired one-time codes.
+func (s *mserver) reapGuests() {
+	ticker := time.NewTicker(time.Hour)
+	defer ticker.Stop()
+	for range ticker.C {
+		cutoff := time.Now().Add(-time.Duration(signupTokenMaxAge) * time.Second)
+		if n, err := s.pg.Guest.DeleteUnverifiedBefore(cutoff); err != nil {
+			s.l.Warnw("guest reaper: could not delete unverified guests", zap.Error(err))
+		} else if n > 0 {
+			s.l.Infow("guest reaper: removed unverified guests", "count", n)
+		}
+		if n, err := s.pg.GuestCode.DeleteExpiredBefore(time.Now()); err != nil {
+			s.l.Warnw("guest reaper: could not delete expired codes", zap.Error(err))
+		} else if n > 0 {
+			s.l.Debugw("guest reaper: removed expired codes", "count", n)
+		}
+	}
+}
+
+func (s *mserver) handleUpdateGuest(r *http.Request, guestId uuid.UUID) (interface{}, error) {
+	type request struct {
+		Name        string
+		FullName    string
+		Description string
+	}
+	var params request
+	if err := decodeRequest(r, &params); err != nil {
+		return nil, err
+	}
 	if strings.TrimSpace(params.Name) == "" {
 		return nil, BadRequestError("name cannot contain only white space characters")
 	}
-	guest, _ := s.pg.Guest.Get(guestId)
-
-	if params.Email != "" && params.Email != guest.Email {
-		return nil, BadRequestError("change of email is not yet supported")
-	}
-	return s.pg.Guest.Update(params.Email, params.Name, guest.Id)
+	// Email is the login identity and is intentionally not updatable here.
+	return s.pg.Guest.UpdateProfile(guestId, params.Name, params.FullName, params.Description)
 }

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -78,6 +78,8 @@ func (s *mserver) routes() {
 	s.mGET("/guest/likes", s.guestOnly(s.handleGuestLikes))
 	s.mGET("/guest/likes/{photoid}", s.guestOnly(s.handleGuestLikePhoto))
 	s.mGET("/guest/verify", s.mResponse(s.handleVerifyGuest))
+	s.mPUT("/guest/login", s.mResponse(s.handleGuestLogin))
+	s.mPUT("/guest/login/verify", s.mResponse(s.handleGuestLoginVerify))
 	s.mPUT("/likes/{photoid}/like", s.guestOnly(s.handleLikePhoto))
 	s.mPUT("/likes/{photoid}/unlike", s.guestOnly(s.handleUnlikePhoto))
 	s.mGET("/likes/{photoid}", s.loginInfo(s.handlePhotoLikes))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -51,9 +51,14 @@ func newServer(prefixPath string, logger *zap.SugaredLogger) *mserver {
 	)
 	s.store.Options = &sessions.Options{
 		Path:     "/api",
-		MaxAge:   60 * 60 * 24,
 		HttpOnly: true,
+		Secure:   config.SecureCookies(),
+		SameSite: http.SameSiteLaxMode,
 	}
+	// Align the securecookie codec TTL with the cookie MaxAge. NewCookieStore
+	// defaults the codec to 30 days but replacing Options above leaves it stuck;
+	// MaxAge sets both, so signatures and browser cookies expire together.
+	s.store.MaxAge(Session_Month)
 	gob.Register(AuthUser{})
 	gob.Register(SessionGuest{})
 
@@ -76,6 +81,9 @@ func newServer(prefixPath string, logger *zap.SugaredLogger) *mserver {
 	//start async job channel:
 	wg.Add(1)
 	go worker(jobChan)
+
+	//periodically reap unverified guests and expired one-time codes:
+	go s.reapGuests()
 
 	//init google auth:
 	s.tokenFile = config.ServicePath("token.json")

--- a/tmpl/login-code-email.html
+++ b/tmpl/login-code-email.html
@@ -1,0 +1,40 @@
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+        <title>Mellowtech Photos</title>
+        <style>
+            body{
+                font-family: helvetica, sans-serif;
+                line-height: 1.5em;
+                font-size: 0.9em;
+                font-weight: 400;
+            }
+            h2{
+                font-family: Helvetica, sans-serif;
+                font-size: 1.0em;
+                font-weight: 600;
+                text-transform: uppercase;
+                margin-bottom: 0px;
+                margin-top: 30px;
+                color: green;
+                letter-spacing: 0.3em;
+            }
+            .code{
+                font-family: monospace;
+                font-size: 1.8em;
+                font-weight: 700;
+                letter-spacing: 0.3em;
+                margin: 20px 0;
+            }
+        </style>
+    </head>
+
+    <body>
+        <h2>Your Mellowtech Photos login code</h2>
+        Hi {{.Name}}, use this code to sign in:
+        <div class="code">{{.Code}}</div>
+        <p>
+            The code is valid for a short time. If you didn't request it, you can ignore this email.
+        </p>
+    </body>
+</html>


### PR DESCRIPTION
Second of the guest-auth redesign PRs (builds on #37). This is the behavior change: the new signup/login flow + cookie hardening. **Breaking for the live mphotos-ui guest flow — accepted** (adoption lands later in mphotos-svelte).

## What changed

**Signup → link with a real token**
- `handleCreateGuest` creates a **pending** guest and emails an unguessable, single-use, expiring signup token (`generateOAuthState`-style). **No cookie is issued until the link is clicked** — fixing the old premature-cookie hole. Returning verified email → "please log in"; unverified → refresh profile + resend link.
- `handleVerifyGuest` resolves the token via `FindSignup`, activates the guest, deletes the token, then issues the cookie. (The old "code" was the guest's own uuid — infinitely valid and reusable; gone.)

**Login → email one-time code**
- `POST /guest/login {email}` emails a 6-digit code to a *verified* guest and **always returns a neutral message** (never reveals whether an email is registered).
- `POST /guest/login/verify {email, code}` consumes the code (single-use via `ConsumeLogin`) and signs in. Returning guests log in with email alone — no name matching.

**Cookie hardening**
- `Secure` (config-gated by new `SecureCookies()`) + `SameSite=Lax`.
- `store.MaxAge(Session_Month)` aligns the securecookie codec TTL with the 30-day cookie (they previously disagreed — browser 1yr vs codec 30d). Guest cookie is now a real 30-day TTL; on expiry the guest re-logs-in via OTP.
- The read path (`guestUUID`) now gates on `HasVerified` — verification is finally enforced.

**Robustness**
- Hourly `reapGuests` goroutine: removes unverified guests past the 24h signup window (cascading comments/likes) and purges expired codes.
- Nil email service (`s.ms`) now returns a clean error instead of nil-panicking.
- Guest profile update edits name/fullName/description; email stays immutable (it's the login identity).

## Config

New `server.secureCookies` (bool): `true` in `config_example.yaml` (prod/HTTPS), `false` in `config_test.yaml` (dev/http). Asserted by `config_test.go`. Deployments must set it appropriately — behind nginx HTTPS it should be `true`.

## Notes

- **CSRF:** `SameSite=Lax` is the baseline cookie mitigation and is sufficient here because the app is strictly same-origin. Dedicated CSRF tokens were not added (consistent with the rest of the app).
- **Testing:** the security-critical token logic (single-use / expiry / consume) is covered by the DAO tests in #37. Handler orchestration isn't — `internal/server` has no test harness yet (parked as a separate test session). Handlers are thin wrappers over tested DAO methods; `make ci` is green.
- Constants (tunable): guest cookie 30d, signup token 24h, login code 15min.

## Next

PR 3 — profile exposure (`fullName`/`description` in own view, `description` on public comments/likes, owner `GET /guests`).