### PR TITLE
Expose guest profile: public description, owner guest list

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -166,3 +166,64 @@ photostream).
 For the UI, this means the camera page can call
 `GET /api/photos?cameraModel=<model>` for both audiences and drop the client-side
 `.filter(p => p.cameraModel === model)` along with the `isUser` fetch branch.
+
+---
+
+# Migration Guide — Database v5 / Guest Auth Redesign
+
+This release hardens and enriches the guest flow. Unlike the v4 change, the guest
+API **is breaking**: name+email login is gone, replaced by email one-time-code
+login and an expiring signup link. The currently deployed `mphotos-ui` guest
+sign-in **will stop working** once this is deployed — that is expected and
+accepted; guest sign-in returns when `mphotos-svelte` adopts the new flow.
+Comments and likes stay readable throughout.
+
+## Server / deployment
+
+`DbVersion` 4 → 5. As before, the server does **not** auto-migrate.
+
+```sh
+pg_dump ... > mphotos-pre-v5.sql     # habit before any schema change
+./mphotos db upgrade                  # v4 -> v5
+./mphotos db version                  # should report 5
+```
+
+`upgradeToV5` adds `fullname`/`description` to `guest`, creates the `guestcode`
+table, and **grandfathers every existing guest to `verified=true`**. That last
+step is essential: under the old flow the verified flag was unenforced, so legacy
+guests were active regardless. It keeps every guest, lets them all log in via the
+new email→code flow, and stops the new reaper from deleting them.
+
+**Data preservation:** existing guest rows, comments and likes are untouched;
+existing guest cookies keep working (same keys, same 30-day codec window, and
+grandfathered guests pass the new verified check).
+
+**New config key:** `server.secureCookies` (bool). Set it **`true` in production**
+(cookies are served over HTTPS behind nginx); `false` for local http dev. It adds
+the `Secure` flag to all session cookies. `SameSite=Lax` is now set in code.
+
+## Guest API — what changed
+
+| Endpoint | Change |
+| --- | --- |
+| `PUT /api/guest` | Signup only. Body `{email, name, fullName?, description?}`. Creates a **pending** guest and emails a verification **link**; **no cookie** until it is clicked. Returning verified email → "please log in". |
+| `GET /api/guest/verify?code=<token>` | Activates from the emailed single-use token (was the guest's uuid), then signs in. |
+| `PUT/POST /api/guest/login` | **New.** Body `{email}`. Emails a 6-digit code to a verified guest; always returns a neutral message (never leaks whether the email exists). |
+| `PUT/POST /api/guest/login/verify` | **New.** Body `{email, code}`. Consumes the code (single use) and signs in. |
+| `PUT /api/guest/update` | Body is now `{name, fullName?, description?}`. Email is immutable (it's the login identity). |
+| `GET /api/guests` | **New, owner-only.** Full guest records incl. `fullName`/`email`. |
+| Comments / likes responses | Now carry the guest `description` alongside `name` (public). `fullName` and `email` are never in public responses. |
+
+Cookie: guests now expire after **30 days** and must re-login (email→code). The
+read path enforces `verified`. Login/signup email delivery needs the owner's Gmail
+OAuth token (same mechanism as before).
+
+## UI adoption (`mphotos-svelte`)
+
+The new guest experience:
+- **Signup:** collect email + nickname (+ optional full name / description) → `PUT /api/guest` → show "check your email" → the link lands on the verify page which calls `GET /api/guest/verify?code=…`.
+- **Login (returning guest):** email → `PUT /api/guest/login` → prompt for the 6-digit code → `PUT /api/guest/login/verify`. No name needed.
+- **Profile:** `full name` + `description` fields; `GET /api/guest` returns them for the guest's own view. Show a guest's `description` next to their comments/likes (now in those responses).
+- **Session:** expect a 30-day expiry — handle the `guestOnly` 401 by prompting a fresh code login.
+
+`mphotos-ui` is intentionally left on the old (now-broken) guest flow.

--- a/cmd/versiondb.go
+++ b/cmd/versiondb.go
@@ -22,11 +22,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// upgradedbCmd represents the upgradedb command
+// versionCmd reports the database schema version. It is read-only: it must never
+// stamp the version, or it desyncs the version marker from the actual schema and
+// makes a subsequent `db upgrade` a silent no-op. Use `db upgrade` to migrate.
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Upgrade Db Version",
-	Long:  `Upgrade Db Version to current. Use with care as it does not do any checking`,
+	Short: "Show the current database schema version",
+	Long:  `Reports the database's current schema version and the version this binary targets. Read-only; use 'db upgrade' to migrate.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := config.InitConfig(); err != nil {
 			fmt.Println(err)
@@ -37,12 +39,17 @@ var versionCmd = &cobra.Command{
 			fmt.Println(err)
 			return
 		}
-		v, err := db.Version.Update()
+		v, err := db.Version.Get()
 		if err != nil {
 			fmt.Println(err)
 			return
 		}
-		fmt.Println("Database upgraded to version:", v.VersionId)
+		fmt.Printf("Database schema version: %d (this binary targets %d)\n", v.VersionId, dao.DbVersion)
+		if v.VersionId < dao.DbVersion {
+			fmt.Println("Run 'db upgrade' to migrate to the latest version.")
+		} else if v.VersionId > dao.DbVersion {
+			fmt.Println("Warning: database is newer than this binary.")
+		}
 	},
 }
 

--- a/internal/dao/guest_test.go
+++ b/internal/dao/guest_test.go
@@ -104,6 +104,32 @@ func TestGuestDeleteCascade(t *testing.T) {
 	}
 }
 
+func TestReactionListByPhotoCarriesDescription(t *testing.T) {
+	pgdb := openAndCreateTestDb(t)
+	defer deleteAndCloseTestDb(pgdb, t)
+
+	g, _ := pgdb.Guest.Add("liker", "liker@example.com")
+	if _, err := pgdb.Guest.UpdateProfile(g.Id, "liker", "Real Name", "loves landscapes"); err != nil {
+		t.Fatalf("could not set description: %v", err)
+	}
+	photoId := uuid.New()
+	if err := pgdb.Reaction.Add(&Reaction{GuestId: g.Id, PhotoId: photoId, Kind: "like"}); err != nil {
+		t.Fatalf("could not add reaction: %v", err)
+	}
+
+	rs, err := pgdb.Reaction.ListByPhoto(photoId)
+	if err != nil {
+		t.Fatalf("ListByPhoto failed: %v", err)
+	}
+	if len(rs) != 1 {
+		t.Fatalf("expected 1 reaction, got %d", len(rs))
+	}
+	// Public projection carries nickname + description, never full name/email.
+	if rs[0].Name != "liker" || rs[0].Description != "loves landscapes" || rs[0].Kind != "like" {
+		t.Errorf("unexpected public reaction: %+v", rs[0])
+	}
+}
+
 func TestGuestCodes(t *testing.T) {
 	pgdb := openAndCreateTestDb(t)
 	defer deleteAndCloseTestDb(pgdb, t)

--- a/internal/dao/reaction.go
+++ b/internal/dao/reaction.go
@@ -49,7 +49,7 @@ func (dao *ReactionPG) ListByGuest(guestId uuid.UUID) ([]uuid.UUID, error) {
 }
 
 func (dao *ReactionPG) ListByPhoto(photoId uuid.UUID) ([]*GuestReaction, error) {
-	const stmt = "select name,kind FROM reaction, guest WHERE photoId = $1 AND reaction.guestId = guest.id"
+	const stmt = "select name,description,kind FROM reaction, guest WHERE photoId = $1 AND reaction.guestId = guest.id"
 	ret := []*GuestReaction{}
 	err := dao.db.Select(&ret, stmt, photoId)
 	return ret, err

--- a/internal/dao/types.go
+++ b/internal/dao/types.go
@@ -81,8 +81,9 @@ type Guest struct {
 // GuestReaction is the public view of a reaction. It deliberately carries no
 // email: it is serialized by the unauthenticated GET /likes/{photoid} route.
 type GuestReaction struct {
-	Name string `json:"name"`
-	Kind string `json:"kind"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Kind        string `json:"kind"`
 }
 
 type Photo struct {

--- a/internal/server/guest.go
+++ b/internal/server/guest.go
@@ -116,11 +116,12 @@ func (s *mserver) handlePhotoComments(r *http.Request, loggedIn bool) (interface
 		return nil, BadRequestError("Could not parse img id")
 	} else {
 		type resp struct {
-			Id      int       `json:"id"`
-			Name    string    `json:"name"`
-			PhotoId uuid.UUID `json:"photoId"`
-			Time    time.Time `json:"time"`
-			Body    string    `json:"body"`
+			Id          int       `json:"id"`
+			Name        string    `json:"name"`
+			Description string    `json:"description"`
+			PhotoId     uuid.UUID `json:"photoId"`
+			Time        time.Time `json:"time"`
+			Body        string    `json:"body"`
 		}
 		comments, err := s.pg.Comment.ListByPhoto(photoId)
 		if err != nil {
@@ -129,7 +130,7 @@ func (s *mserver) handlePhotoComments(r *http.Request, loggedIn bool) (interface
 		ret := []*resp{}
 		for _, c := range comments {
 			u, _ := s.pg.Guest.Get(c.GuestId)
-			ret = append(ret, &resp{Id: c.Id, Name: u.Name, PhotoId: c.PhotoId, Time: c.Time, Body: c.Body})
+			ret = append(ret, &resp{Id: c.Id, Name: u.Name, Description: u.Description, PhotoId: c.PhotoId, Time: c.Time, Body: c.Body})
 		}
 		return ret, nil
 	}
@@ -137,6 +138,12 @@ func (s *mserver) handlePhotoComments(r *http.Request, loggedIn bool) (interface
 
 func (s *mserver) handleGuest(r *http.Request, uuid uuid.UUID) (interface{}, error) {
 	return s.pg.Guest.Get(uuid)
+}
+
+// handleGuests lists all guests for the owner. It is authOnly, so it may return
+// the owner-only fields (full name, email) that public responses never expose.
+func (s *mserver) handleGuests(r *http.Request) (interface{}, error) {
+	return s.pg.Guest.List()
 }
 
 func (s *mserver) handleLikePhoto(r *http.Request, guestId uuid.UUID) (interface{}, error) {

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -70,6 +70,7 @@ func (s *mserver) routes() {
 
 	s.mPUT("/comments/{img}", s.guestOnly(s.handleCommentPhoto))
 	s.mGET("/comments/{img}", s.loginInfo(s.handlePhotoComments))
+	s.mGET("/guests", s.authOnly(s.handleGuests))
 	s.mPUT("/guest", s.mResponse(s.handleCreateGuest))
 	s.mGET("/guest", s.guestOnly(s.handleGuest))
 	s.mPUT("/guest/update", s.guestOnly(s.handleUpdateGuest))


### PR DESCRIPTION
Third and final PR of the guest-auth redesign (after #37, #38). Completes the richer-profile surface agreed on: **nickname + description public; full name + email owner-only.**

## Changes

- **`description` public on comments and likes.** `GuestReaction` and its `ListByPhoto` query now carry `description`; the comments response includes it (the handler already fetched the guest per row). So a guest's short blurb can show next to their comments/likes. **`fullName` and `email` are never added to these public projections.**
- **New owner-only `GET /api/guests`** (`authOnly`) → `Guest.List()` with full records (`fullName`, `email`, `verified`, …), for an owner-facing guest view.
- The guest's own view (`GET /api/guest` returns `fullName`/`description`) and profile update landed in #38; this PR finishes the *public/owner* exposure.

## Visibility check

The full `Guest` struct (with `email`/`fullName`) is only ever serialized on `guestOnly` (the guest's own) or `authOnly` (owner) routes. Every public path — comments, likes — uses a `name` + `description` projection. No cross-guest or owner-only data leaks publicly.

## Docs

Extended `MIGRATION.md` with a complete **v5 / guest** section: the `db upgrade` (v4→v5) and `secureCookies: true` deploy steps, the breaking guest-API table, the data-preservation guarantees (grandfathering, cookies keep working), and the `mphotos-svelte` adoption guide.

## Testing

`make ci` green. Added a DAO test asserting the public like-projection carries nickname + description (and the expected fields only).

## Backend guest redesign: done

With this merged, the backend guest work is complete — cookie TTL + hardening, email→OTP login, expiring signup verification + reaping, and the richer profile. Remaining is the **`mphotos-svelte` frontend adoption** (separate effort, guided by `MIGRATION.md`); `mphotos-ui` stays on the old flow until cutover.