### PR TITLE
Make db migrations multi-step

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,11 +54,14 @@ parallel-safe. `MPHOTOS_DB_HOST`, `MPHOTOS_DB_USER`, … override the file.
   names are derived by lowercasing Go field names (`getStructFields` in `sqlx.go`), so field and
   column names must match case-insensitively. Build statements with `buildInsertNamed` /
   `buildUpdateNamed2`; ad-hoc queries are plain SQL with `$1` placeholders.
-- **Schema changes are hand-rolled migrations** — no framework. Bump `DbVersion` in `types.go`,
-  add `schemaVN` + `schemaV(N-1)toVN` + `deleteSchemaVN` in `schema.go`, write `upgradeToVN` and
-  wire it into the dispatch in `migrate.go` (currently hardcoded to `upgradeToV3` — it must be
-  edited, not just appended to), and update the `schemaV3`/`deleteSchemaV3` references in
-  `dao.go`. Upgrades only support a single version step at a time.
+- **Schema changes are hand-rolled migrations** — no framework, but multi-step. To add version N:
+  bump `DbVersion`/`DbDescription` in `types.go`; add `schemaV(N-1)toVN` (the ALTER/DDL delta) and
+  rename the full-schema/teardown consts to `schemaVN`/`deleteSchemaVN` in `schema.go` (updating
+  their references in `dao.go`'s `CreateTables`/`DeleteTables`); write `upgradeToVN(pgdb)` that
+  applies only the delta — it must **not** stamp the version; and **append** `N: upgradeToVN` to the
+  `migrations` map in `migrate.go` (never delete older entries — the whole chain is kept). `UpgradeDb`
+  loops from the db's current version up to `DbVersion`, applying each registered step and stamping
+  the version after each via `Version.Set`, so any older db walks forward one step at a time.
 - **Config**: viper + YAML, accessed through free functions in `internal/config`. Searched in
   `$HOME/.mphotos`, `/etc/mphotos`, `.` (tests also `../..`). `config_example.yaml` documents
   every section — and is asserted by `internal/config/config_test.go`, so keep it in sync.

--- a/internal/dao/dao.go
+++ b/internal/dao/dao.go
@@ -117,6 +117,7 @@ type UserDAO interface {
 type VersionDAO interface {
 	Get() (*Version, error)
 	Update() (*Version, error)
+	Set(versionId int) (*Version, error)
 	IsCurrent() (bool, error)
 }
 

--- a/internal/dao/migrate.go
+++ b/internal/dao/migrate.go
@@ -4,16 +4,22 @@ import (
 	"fmt"
 )
 
-// for now this is just hard coded
-func canUpgradeDb(pgdb *PGDB) bool {
-	if v, err := pgdb.Version.Get(); err != nil {
-		logger.Errorw("could not get Version info", "error", err)
-		return false
-	} else {
-		return v.VersionId+1 == DbVersion
-	}
+// migrations maps a target version to the function that upgrades the database
+// from the immediately prior version to it (e.g. migrations[5] takes a v4 db to
+// v5). Every step is kept here — never delete an entry — so the full upgrade
+// chain is retained and any older database can be walked forward one version at
+// a time. Add new steps here; do not replace old ones.
+//
+// A migration must only apply its schema/data changes; it must NOT stamp the
+// version. UpgradeDb stamps each version after the step succeeds.
+var migrations = map[int]func(*PGDB) error{
+	5: upgradeToV5,
 }
 
+// UpgradeDb brings the database up to the binary's DbVersion, applying each
+// intervening migration in order and stamping the version after each step (so a
+// crash mid-walk leaves a consistent, resumable marker). A fresh database is
+// created directly at the latest schema.
 func UpgradeDb() error {
 	var err error
 	var pgdb *PGDB
@@ -22,31 +28,46 @@ func UpgradeDb() error {
 	}
 	hasVersion := pgdb.tableExists("version")
 	hasPhotos := pgdb.tableExists("photos")
-	if hasVersion {
-		if isCurrent, err := pgdb.Version.IsCurrent(); err != nil {
-			return err
-		} else if isCurrent {
-			logger.Info("Database is up to date")
-			return nil
-		} else if canUpgradeDb(pgdb) {
-			return upgradeToV5(pgdb)
-		} else {
-			return fmt.Errorf("cannot upgrade database, wrong current version")
+	if !hasVersion {
+		if hasPhotos {
+			return fmt.Errorf("cannot upgrade database")
 		}
-	} else if hasPhotos {
-		return fmt.Errorf("cannot upgrade database")
-	} else {
 		logger.Info("No database exists. Creating a fresh db")
-		if err = pgdb.CreateTables(); err != nil {
+		return pgdb.CreateTables()
+	}
+
+	v, err := pgdb.Version.Get()
+	if err != nil {
+		return err
+	}
+	if v.VersionId == DbVersion {
+		logger.Info("Database is up to date")
+		return nil
+	}
+	if v.VersionId > DbVersion {
+		return fmt.Errorf("database version %d is newer than this binary (%d)", v.VersionId, DbVersion)
+	}
+
+	for target := v.VersionId + 1; target <= DbVersion; target++ {
+		mig, ok := migrations[target]
+		if !ok {
+			return fmt.Errorf("no migration registered to reach version %d", target)
+		}
+		logger.Infow("Upgrading database", "from", target-1, "to", target)
+		if err := mig(pgdb); err != nil {
+			return err
+		}
+		if _, err := pgdb.Version.Set(target); err != nil {
 			return err
 		}
 	}
+	logger.Infow("Database upgraded", "version", DbVersion)
 	return nil
 }
 
+// upgradeToV5 takes a v4 database to v5. It does not stamp the version — the
+// UpgradeDb loop does that after the step succeeds.
 func upgradeToV5(pgdb *PGDB) error {
-	logger.Infow("Upgrading Db to Version", "version", DbVersion)
-
 	if _, err := pgdb.db.Exec(schemaV4toV5); err != nil {
 		return err
 	}
@@ -61,13 +82,6 @@ func upgradeToV5(pgdb *PGDB) error {
 	}
 	if n, _ := res.RowsAffected(); n > 0 {
 		logger.Infow("grandfathered existing guests to verified", "count", n)
-	}
-
-	logger.Info("Db Updated. Change Version Info")
-	if v, err := pgdb.Version.Update(); err != nil {
-		return err
-	} else {
-		logger.Infow("Updated Db to version", "version", v.VersionId)
 	}
 	return nil
 }

--- a/internal/dao/migrate_test.go
+++ b/internal/dao/migrate_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/google/uuid"
 )
 
-// TestUpgradeToV5 rewinds a freshly created (v5) database to the v4 shape — no
+// TestUpgradeWalk rewinds a freshly created (v5) database to the v4 shape — no
 // fullname/description columns, no guestcode table, version 4, with an
-// unverified legacy guest — then runs upgradeToV5 and asserts the schema is
-// extended and every existing guest is grandfathered to verified=true. The
-// drop/recreate harness only ever creates the latest schema, so this is the only
-// coverage of the migration path.
-func TestUpgradeToV5(t *testing.T) {
+// unverified legacy guest — then runs the real UpgradeDb walk and asserts the
+// schema is extended, the version is stamped, and every existing guest is
+// grandfathered to verified=true. The drop/recreate harness only ever creates
+// the latest schema, so this is the only coverage of the migration path.
+func TestUpgradeWalk(t *testing.T) {
 	pgdb := openAndCreateTestDb(t)
 	defer deleteAndCloseTestDb(pgdb, t)
 
@@ -35,11 +35,11 @@ func TestUpgradeToV5(t *testing.T) {
 		t.Fatalf("could not insert legacy guest: %v", err)
 	}
 
-	if err := upgradeToV5(pgdb); err != nil {
-		t.Fatalf("upgradeToV5 failed: %v", err)
+	// UpgradeDb walks v4 -> v5 via the migrations map and stamps the version.
+	if err := UpgradeDb(); err != nil {
+		t.Fatalf("UpgradeDb failed: %v", err)
 	}
 
-	// Version bumped.
 	if v, err := pgdb.Version.Get(); err != nil {
 		t.Fatalf("could not read version: %v", err)
 	} else if v.VersionId != DbVersion {
@@ -61,5 +61,32 @@ func TestUpgradeToV5(t *testing.T) {
 	// guestcode table exists and is usable after the upgrade.
 	if err := pgdb.GuestCode.Issue(gid, GuestCodeLogin, "123456", time.Now().Add(time.Minute)); err != nil {
 		t.Errorf("guestcode table not usable after upgrade: %v", err)
+	}
+}
+
+// TestUpgradeUpToDate: a database already at the latest version is a no-op.
+func TestUpgradeUpToDate(t *testing.T) {
+	pgdb := openAndCreateTestDb(t)
+	defer deleteAndCloseTestDb(pgdb, t)
+
+	if err := UpgradeDb(); err != nil {
+		t.Fatalf("UpgradeDb on current db should be a no-op, got: %v", err)
+	}
+	if v, _ := pgdb.Version.Get(); v.VersionId != DbVersion {
+		t.Errorf("expected version %d got %d", DbVersion, v.VersionId)
+	}
+}
+
+// TestUpgradeNewerThanBinary: a database ahead of the binary must error, not
+// silently proceed.
+func TestUpgradeNewerThanBinary(t *testing.T) {
+	pgdb := openAndCreateTestDb(t)
+	defer deleteAndCloseTestDb(pgdb, t)
+
+	if _, err := pgdb.Version.Set(DbVersion + 1); err != nil {
+		t.Fatalf("could not set version ahead: %v", err)
+	}
+	if err := UpgradeDb(); err == nil {
+		t.Error("expected an error upgrading a db newer than the binary")
 	}
 }

--- a/internal/dao/version.go
+++ b/internal/dao/version.go
@@ -21,8 +21,17 @@ func NewVersionPG(db *sqlx.DB) *VersionPG {
 	return &VersionPG{db, fields, uStmt, gStmt}
 }
 
+// Update stamps the version row to the binary's current DbVersion. Used when
+// creating a fresh database.
 func (dao *VersionPG) Update() (*Version, error) {
-	v := Version{DbVersion, DbDescription}
+	return dao.Set(DbVersion)
+}
+
+// Set stamps the version row to an explicit version. UpgradeDb calls it after
+// each migration step so the marker advances one version at a time and a crash
+// mid-upgrade leaves a consistent, resumable version.
+func (dao *VersionPG) Set(versionId int) (*Version, error) {
+	v := Version{versionId, DbDescription}
 	if _, err := dao.db.NamedExec(dao.updateVersionStmt, &v); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Groundwork before stacking the guest avatar (v6) and Google-login (v7) migrations. Makes the hand-rolled migration system walk multiple versions in one run, so a database several versions behind upgrades in a single binary/deploy.

## Why

The migration dispatch was single-step: `canUpgradeDb` required the db to be exactly one version behind, and each release **replaced** the previous `upgradeToVN`. That means a v4 database can't reach v6/v7 without deploying an intermediate binary per version — and once we add v6/v7, prod (currently on v4) would be cornered. It's also the class of problem behind the recent `db version` footgun (version marker desyncing from schema).

## What changed

- **`migrate.go`** — a `migrations` map keyed by target version (`{5: upgradeToV5}`, **append-only** — old entries are never deleted, so the full chain is retained). `UpgradeDb` now **loops** from the db's current version up to `DbVersion`, applying each registered step and stamping the version after each. Adds a proper "database is newer than this binary" guard. `canUpgradeDb` removed.
- **`version.go`** — new `Version.Set(n)` stamps an explicit version; `Update()` delegates to it. Migrations no longer stamp the version themselves — the loop owns that, so a crash mid-walk leaves a consistent, resumable marker.
- **`upgradeToV5`** — kept (chain retained), stripped of its own version-stamping.
- **`CLAUDE.md`** — migration recipe updated to the accumulate-forward model (append a map entry; steps don't stamp the version).

## No version bump

`DbVersion` stays **5** — this is pure framework, no schema change. Fresh installs and existing v5 databases are unaffected; a v4 db still walks to v5 exactly as before (now via the loop).

## Testing

`make ci` green. Migration tests now exercise the real `UpgradeDb` walk (v4→v5, asserting schema + version stamp + guest grandfathering), plus an up-to-date no-op case and a newer-than-binary error case. The multi-version walk gets live coverage as soon as v6 lands (a v4→v6 walk).

## Next

Then avatar upload (v6) and Google guest login (v7) land as appended map entries — and a v4 prod walks v4→v5→v6→v7 in one deploy.