### PR TITLE
Add Google-based guest login

### DIFF
--- a/config_example.yaml
+++ b/config_example.yaml
@@ -18,6 +18,7 @@ auth:
       - msvens@gmail.com
     loginRedirectUrl: http://localhost:8050/api/auth/login/callback
     uiRedirectPath: /        # where to send the browser after login (success or failure with ?error=)
+    guestRedirectUrl: http://localhost:8050/api/auth/guest/callback  # OAuth callback for guest Google login; register in the Google console
 
 session:
   authKey: authKey #64 bytes recommended

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -221,6 +221,13 @@ func AuthGoogleUIRedirectPath() string {
 	return p
 }
 
+// GuestGoogleRedirectUrl is the OAuth callback URL for the guest Google login
+// flow. It must be a distinct path from the owner login callback and registered
+// as an authorized redirect URI in the Google console.
+func GuestGoogleRedirectUrl() string {
+	return viper.GetString("auth.google.guestRedirectUrl")
+}
+
 func SessionAuthcKey() string {
 	return viper.GetString("session.authKey")
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -83,6 +83,9 @@ func TestConfigFile(t *testing.T) {
 	if AuthGoogleLoginRedirectUrl() != "http://localhost:8050/api/auth/login/callback" {
 		t.Errorf("unexpected login redirect url: %v", AuthGoogleLoginRedirectUrl())
 	}
+	if GuestGoogleRedirectUrl() != "http://localhost:8050/api/auth/guest/callback" {
+		t.Errorf("unexpected guest redirect url: %v", GuestGoogleRedirectUrl())
+	}
 	//google config:
 	if GoogleClientId() != "clientId" {
 		t.Errorf("expected clientId got %v", GoogleClientId())

--- a/internal/dao/dao.go
+++ b/internal/dao/dao.go
@@ -61,10 +61,12 @@ type GuestDAO interface {
 	Verify(id uuid.UUID) (*Guest, error)
 	Get(id uuid.UUID) (*Guest, error)
 	GetByEmail(email string) (*Guest, error)
+	GetByGoogleId(googleId string) (*Guest, error)
 	Has(id uuid.UUID) bool
 	HasVerified(id uuid.UUID) bool
 	HasByEmail(email string) bool
 	HasByName(name string) bool
+	SetGoogleId(id uuid.UUID, googleId string) (*Guest, error)
 	Update(email string, name string, id uuid.UUID) (*Guest, error)
 	UpdateProfile(id uuid.UUID, name, fullName, description string) (*Guest, error)
 	UpdateAvatar(avatar string, id uuid.UUID) (*Guest, error)
@@ -193,7 +195,7 @@ func (pgd *PGDB) tableExists(table string) bool {
 }
 
 func (pgd *PGDB) CreateTables() error {
-	if _, err := pgd.db.Exec(schemaV6); err != nil {
+	if _, err := pgd.db.Exec(schemaV7); err != nil {
 		return err
 	} else { //make sure version is correct
 		_, err = pgd.Version.Update()
@@ -205,6 +207,6 @@ func (pgd *PGDB) CreateTables() error {
 }
 
 func (pgd *PGDB) DeleteTables() error {
-	_, err := pgd.db.Exec(deleteSchemaV6)
+	_, err := pgd.db.Exec(deleteSchemaV7)
 	return err
 }

--- a/internal/dao/guest.go
+++ b/internal/dao/guest.go
@@ -109,6 +109,21 @@ func (dao *GuestPG) UpdateProfile(id uuid.UUID, name, fullName, description stri
 	return dao.Get(id)
 }
 
+// GetByGoogleId returns the guest linked to a Google account id (OIDC sub).
+func (dao *GuestPG) GetByGoogleId(googleId string) (*Guest, error) {
+	ret := Guest{}
+	err := dao.db.Get(&ret, "SELECT * FROM guest WHERE googleid = $1", googleId)
+	return &ret, err
+}
+
+// SetGoogleId links a guest to a Google account id.
+func (dao *GuestPG) SetGoogleId(id uuid.UUID, googleId string) (*Guest, error) {
+	if _, err := dao.db.Exec("UPDATE guest SET googleid = $1 WHERE id = $2", googleId, id); err != nil {
+		return nil, err
+	}
+	return dao.Get(id)
+}
+
 // UpdateAvatar sets the guest's avatar reference (the file extension, e.g.
 // ".jpg", or "" to clear it).
 func (dao *GuestPG) UpdateAvatar(avatar string, id uuid.UUID) (*Guest, error) {

--- a/internal/dao/guest_test.go
+++ b/internal/dao/guest_test.go
@@ -7,6 +7,39 @@ import (
 	"github.com/google/uuid"
 )
 
+func TestGuestGoogleId(t *testing.T) {
+	pgdb := openAndCreateTestDb(t)
+	defer deleteAndCloseTestDb(pgdb, t)
+
+	g, _ := pgdb.Guest.Add("goog", "goog@example.com")
+
+	// No link yet.
+	if _, err := pgdb.Guest.GetByGoogleId("sub-123"); err == nil {
+		t.Error("expected miss for an unlinked google id")
+	}
+
+	// Link it, then resolve by google id.
+	if _, err := pgdb.Guest.SetGoogleId(g.Id, "sub-123"); err != nil {
+		t.Fatalf("SetGoogleId failed: %v", err)
+	}
+	if got, err := pgdb.Guest.GetByGoogleId("sub-123"); err != nil {
+		t.Fatalf("GetByGoogleId failed: %v", err)
+	} else if got.Id != g.Id {
+		t.Errorf("expected %v got %v", g.Id, got.Id)
+	}
+
+	// The partial unique index forbids two guests sharing a google id, but many
+	// may keep the empty default.
+	g2, _ := pgdb.Guest.Add("goog2", "goog2@example.com")
+	if _, err := pgdb.Guest.SetGoogleId(g2.Id, "sub-123"); err == nil {
+		t.Error("expected unique-violation linking a second guest to the same google id")
+	}
+	g3, _ := pgdb.Guest.Add("goog3", "goog3@example.com")
+	if g3.GoogleId != "" {
+		t.Errorf("expected empty google id by default, got %q", g3.GoogleId)
+	}
+}
+
 func TestGuestProfileAndReap(t *testing.T) {
 	pgdb := openAndCreateTestDb(t)
 	defer deleteAndCloseTestDb(pgdb, t)

--- a/internal/dao/migrate.go
+++ b/internal/dao/migrate.go
@@ -15,6 +15,7 @@ import (
 var migrations = map[int]func(*PGDB) error{
 	5: upgradeToV5,
 	6: upgradeToV6,
+	7: upgradeToV7,
 }
 
 // UpgradeDb brings the database up to the binary's DbVersion, applying each
@@ -90,5 +91,11 @@ func upgradeToV5(pgdb *PGDB) error {
 // upgradeToV6 takes a v5 database to v6, adding the guest avatar column.
 func upgradeToV6(pgdb *PGDB) error {
 	_, err := pgdb.db.Exec(schemaV5toV6)
+	return err
+}
+
+// upgradeToV7 takes a v6 database to v7, adding the guest Google account id.
+func upgradeToV7(pgdb *PGDB) error {
+	_, err := pgdb.db.Exec(schemaV6toV7)
 	return err
 }

--- a/internal/dao/migrate_test.go
+++ b/internal/dao/migrate_test.go
@@ -23,6 +23,8 @@ func TestUpgradeWalk(t *testing.T) {
 		"ALTER TABLE guest DROP COLUMN fullname",
 		"ALTER TABLE guest DROP COLUMN description",
 		"ALTER TABLE guest DROP COLUMN avatar",
+		"ALTER TABLE guest DROP COLUMN googleid",
+		"DROP INDEX IF EXISTS guest_googleid_idx",
 		"DROP TABLE IF EXISTS guestcode",
 		"UPDATE version SET versionId = 4",
 	} {

--- a/internal/dao/schema.go
+++ b/internal/dao/schema.go
@@ -19,7 +19,15 @@ const schemaV4toV5 = `
 const schemaV5toV6 = `
 	ALTER TABLE guest ADD COLUMN avatar TEXT NOT NULL DEFAULT '';
 `
-const schemaV6 = `
+
+// schemaV6toV7 adds the Google account id (OIDC 'sub') for guests who sign in
+// with Google. The partial unique index keeps it unique among linked guests
+// while allowing many ” (email-only) guests.
+const schemaV6toV7 = `
+	ALTER TABLE guest ADD COLUMN googleid TEXT NOT NULL DEFAULT '';
+	CREATE UNIQUE INDEX guest_googleid_idx ON guest (googleid) WHERE googleid <> '';
+`
+const schemaV7 = `
 CREATE TABLE IF NOT EXISTS album (
 	Id UUID,
 	name TEXT,
@@ -98,11 +106,14 @@ CREATE TABLE IF NOT EXISTS guest (
 	fullname TEXT NOT NULL DEFAULT '',
 	description TEXT NOT NULL DEFAULT '',
 	avatar TEXT NOT NULL DEFAULT '',
+	googleid TEXT NOT NULL DEFAULT '',
 	verified BOOLEAN NOT NULL,
 	verifytime TIMESTAMP NOT NULL,
 	CONSTRAINT guest_email UNIQUE (email),
 	CONSTRAINT guest_name UNIQUE (name)
 );
+
+CREATE UNIQUE INDEX IF NOT EXISTS guest_googleid_idx ON guest (googleid) WHERE googleid <> '';
 
 CREATE TABLE IF NOT EXISTS guestcode (
 	guestid UUID NOT NULL,
@@ -168,7 +179,7 @@ INSERT INTO version (versionId,description) VALUES (0,'no version set') ON CONFL
 INSERT INTO usert (id, name, bio, pic, driveFolderId, driveFolderName, config) VALUES (23657, '', '', '', '','','{}') ON CONFLICT (id) DO NOTHING;
 `
 
-const deleteSchemaV6 = `
+const deleteSchemaV7 = `
 DROP TABLE IF EXISTS album;
 DROP TABLE IF EXISTS albumphotos;
 DROP TABLE IF EXISTS camera;

--- a/internal/dao/types.go
+++ b/internal/dao/types.go
@@ -6,8 +6,8 @@ import (
 	"time"
 )
 
-const DbVersion = 6
-const DbDescription = "Version 6 adds a guest avatar reference"
+const DbVersion = 7
+const DbDescription = "Version 7 adds a Google account id for guest login"
 
 type Album struct {
 	Id          uuid.UUID  `json:"id"`
@@ -75,6 +75,7 @@ type Guest struct {
 	FullName    string    `json:"fullName"`
 	Description string    `json:"description"`
 	Avatar      string    `json:"avatar"`
+	GoogleId    string    `json:"-"`
 	Verified    bool      `json:"verified"`
 	VerifyTime  time.Time `json:"verifyTime"`
 }

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -279,19 +279,19 @@ func (s *mserver) handleGoogleLoginCallback(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	email, verified, err := fetchGoogleUserinfo(r.Context(), token)
+	info, err := fetchGoogleUserinfo(r.Context(), token)
 	if err != nil {
 		s.l.Errorw("userinfo fetch failed", zap.Error(err))
 		redirTo("exchange_failed")
 		return
 	}
-	if !verified {
-		s.l.Infow("google email not verified", "email", email)
+	if !info.EmailVerified {
+		s.l.Infow("google email not verified", "email", info.Email)
 		redirTo("unauthorized_email")
 		return
 	}
-	if !emailAllowed(email, config.AuthAllowedEmails()) {
-		s.l.Infow("email not in allowlist", "email", email)
+	if !emailAllowed(info.Email, config.AuthAllowedEmails()) {
+		s.l.Infow("email not in allowlist", "email", info.Email)
 		redirTo("unauthorized_email")
 		return
 	}
@@ -325,28 +325,33 @@ func generateLoginCode() (string, error) {
 	return fmt.Sprintf("%06d", n.Int64()), nil
 }
 
-func fetchGoogleUserinfo(ctx context.Context, token *oauth2.Token) (string, bool, error) {
+type googleUserinfo struct {
+	Email         string `json:"email"`
+	EmailVerified bool   `json:"email_verified"`
+	Name          string `json:"name"`
+	Picture       string `json:"picture"`
+	Sub           string `json:"sub"`
+}
+
+func fetchGoogleUserinfo(ctx context.Context, token *oauth2.Token) (*googleUserinfo, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", "https://www.googleapis.com/oauth2/v3/userinfo", nil)
 	if err != nil {
-		return "", false, err
+		return nil, err
 	}
 	req.Header.Set("Authorization", "Bearer "+token.AccessToken)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return "", false, err
+		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
-		return "", false, fmt.Errorf("userinfo: status %d", resp.StatusCode)
+		return nil, fmt.Errorf("userinfo: status %d", resp.StatusCode)
 	}
-	var info struct {
-		Email         string `json:"email"`
-		EmailVerified bool   `json:"email_verified"`
-	}
+	var info googleUserinfo
 	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
-		return "", false, err
+		return nil, err
 	}
-	return info.Email, info.EmailVerified, nil
+	return &info, nil
 }
 
 func emailAllowed(email string, allowlist []string) bool {

--- a/internal/server/guest_google.go
+++ b/internal/server/guest_google.go
@@ -1,0 +1,199 @@
+package server
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/google/uuid"
+	"github.com/msvens/mphotos/internal/config"
+	"github.com/msvens/mphotos/internal/dao"
+	"go.uber.org/zap"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+func (s *mserver) guestLoginStateCookieName() string {
+	return s.cookieName + "-guest-login-state"
+}
+
+// handleGuestGoogleRedirect starts the guest Google login: it stores a single-use
+// CSRF state in a dedicated cookie and redirects to Google. Mirrors the owner
+// login redirect but with the guest OAuth config and no allowlist.
+func (s *mserver) handleGuestGoogleRedirect(w http.ResponseWriter, r *http.Request) {
+	state, err := generateOAuthState()
+	if err != nil {
+		s.l.Errorw("could not generate guest oauth state", zap.Error(err))
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	stateSession, _ := s.store.Get(r, s.guestLoginStateCookieName())
+	stateSession.Values["state"] = state
+	stateSession.Options.MaxAge = oauthLoginStateMaxAge
+	if err := stateSession.Save(r, w); err != nil {
+		s.l.Errorw("could not save guest oauth state cookie", zap.Error(err))
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	http.Redirect(w, r, s.gconfigGuestLogin.AuthCodeURL(state), http.StatusTemporaryRedirect)
+}
+
+// handleGuestGoogleCallback completes the guest Google login: validates the
+// single-use state, exchanges the code, fetches the verified profile, resolves
+// it to a guest (link/create), and issues the guest cookie. Unlike the owner
+// flow there is no email allowlist — any verified Google account may be a guest.
+func (s *mserver) handleGuestGoogleCallback(w http.ResponseWriter, r *http.Request) {
+	redirTo := func(errCode string) {
+		target := config.AuthGoogleUIRedirectPath()
+		if errCode != "" {
+			sep := "?"
+			if strings.Contains(target, "?") {
+				sep = "&"
+			}
+			target = target + sep + "error=" + url.QueryEscape(errCode)
+		}
+		http.Redirect(w, r, target, http.StatusTemporaryRedirect)
+	}
+
+	queryState := r.FormValue("state")
+	stateSession, _ := s.store.Get(r, s.guestLoginStateCookieName())
+	expected, _ := stateSession.Values["state"].(string)
+	// Always expire the state cookie after first use, regardless of outcome.
+	stateSession.Options.MaxAge = -1
+	_ = stateSession.Save(r, w)
+
+	if queryState == "" || expected == "" || queryState != expected {
+		s.l.Info("guest oauth state mismatch")
+		redirTo("invalid_state")
+		return
+	}
+	code := r.FormValue("code")
+	if code == "" {
+		redirTo("invalid_state")
+		return
+	}
+
+	token, err := s.gconfigGuestLogin.Exchange(r.Context(), code)
+	if err != nil {
+		s.l.Errorw("guest login code exchange failed", zap.Error(err))
+		redirTo("exchange_failed")
+		return
+	}
+	info, err := fetchGoogleUserinfo(r.Context(), token)
+	if err != nil {
+		s.l.Errorw("guest userinfo fetch failed", zap.Error(err))
+		redirTo("exchange_failed")
+		return
+	}
+	if !info.EmailVerified || info.Email == "" || info.Sub == "" {
+		s.l.Infow("guest google account not usable", "email", info.Email, "verified", info.EmailVerified)
+		redirTo("unauthorized_email")
+		return
+	}
+
+	guest, err := s.provisionGoogleGuest(info)
+	if err != nil {
+		s.l.Errorw("could not provision google guest", zap.Error(err))
+		redirTo("exchange_failed")
+		return
+	}
+	if err := s.saveGuestCookie(w, r, guest.Id, guestCookieMaxAge); err != nil {
+		s.l.Errorw("could not save guest cookie", zap.Error(err))
+		redirTo("exchange_failed")
+		return
+	}
+	redirTo("")
+}
+
+// provisionGoogleGuest resolves a verified Google profile to a guest: an existing
+// linked guest (by Google id), an existing email-OTP guest (linked by verified
+// email — same person), or a brand-new guest. A newly created guest gets the
+// Google picture imported as their avatar, best-effort.
+func (s *mserver) provisionGoogleGuest(info *googleUserinfo) (*dao.Guest, error) {
+	// 1. Already linked by Google id.
+	if g, err := s.pg.Guest.GetByGoogleId(info.Sub); err == nil {
+		return g, nil
+	}
+	// 2. Existing guest with the same (Google-verified) email → link, and verify
+	//    if they were still pending.
+	if s.pg.Guest.HasByEmail(info.Email) {
+		g, err := s.pg.Guest.GetByEmail(info.Email)
+		if err != nil {
+			return nil, err
+		}
+		if !g.Verified {
+			if _, err := s.pg.Guest.Verify(g.Id); err != nil {
+				return nil, err
+			}
+		}
+		return s.pg.Guest.SetGoogleId(g.Id, info.Sub)
+	}
+	// 3. New guest.
+	displayName := googleDisplayName(info)
+	name := s.dedupGuestName(displayName)
+	g, err := s.pg.Guest.Add(name, info.Email)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := s.pg.Guest.UpdateProfile(g.Id, name, displayName, ""); err != nil {
+		_ = s.pg.Guest.Delete(g.Id)
+		return nil, err
+	}
+	if _, err := s.pg.Guest.Verify(g.Id); err != nil {
+		_ = s.pg.Guest.Delete(g.Id)
+		return nil, err
+	}
+	if _, err := s.pg.Guest.SetGoogleId(g.Id, info.Sub); err != nil {
+		_ = s.pg.Guest.Delete(g.Id)
+		return nil, err
+	}
+	s.importGoogleAvatar(g.Id, info.Picture)
+	return s.pg.Guest.Get(g.Id)
+}
+
+// dedupGuestName returns name, or name-2/name-3/... if the nickname is taken.
+// A redirect flow can't re-prompt, so collisions are resolved automatically.
+func (s *mserver) dedupGuestName(name string) string {
+	if !s.pg.Guest.HasByName(name) {
+		return name
+	}
+	for i := 2; ; i++ {
+		candidate := fmt.Sprintf("%s-%d", name, i)
+		if !s.pg.Guest.HasByName(candidate) {
+			return candidate
+		}
+	}
+}
+
+// importGoogleAvatar downloads a guest's Google profile picture into their
+// avatar. Best-effort: any failure is logged and ignored so it never blocks
+// login. Reuses the SSRF-guarded fetch + resize pipeline from the avatar upload.
+func (s *mserver) importGoogleAvatar(guestId uuid.UUID, pictureURL string) {
+	if pictureURL == "" {
+		return
+	}
+	data, err := fetchRemoteImage(pictureURL)
+	if err != nil {
+		s.l.Infow("could not fetch google avatar", "error", err)
+		return
+	}
+	ext, err := storeGuestAvatar(guestId, bytes.NewReader(data))
+	if err != nil {
+		s.l.Infow("could not store google avatar", "error", err)
+		return
+	}
+	if _, err := s.pg.Guest.UpdateAvatar(ext, guestId); err != nil {
+		s.l.Warnw("could not record google avatar", "error", err)
+	}
+}
+
+// googleDisplayName picks a nickname from a Google profile: the display name, or
+// the email local-part as a fallback.
+func googleDisplayName(info *googleUserinfo) string {
+	if n := strings.TrimSpace(info.Name); n != "" {
+		return n
+	}
+	if at := strings.IndexByte(info.Email, '@'); at > 0 {
+		return info.Email[:at]
+	}
+	return "guest"
+}

--- a/internal/server/guest_google.go
+++ b/internal/server/guest_google.go
@@ -125,7 +125,17 @@ func (s *mserver) provisionGoogleGuest(info *googleUserinfo) (*dao.Guest, error)
 				return nil, err
 			}
 		}
-		return s.pg.Guest.SetGoogleId(g.Id, info.Sub)
+		linked, err := s.pg.Guest.SetGoogleId(g.Id, info.Sub)
+		if err != nil {
+			return nil, err
+		}
+		// Fill an empty avatar from the Google picture; never clobber one the
+		// guest has already set. They can remove it afterwards if they like.
+		if linked.Avatar == "" {
+			s.importGoogleAvatar(linked.Id, info.Picture)
+			return s.pg.Guest.Get(linked.Id)
+		}
+		return linked, nil
 	}
 	// 3. New guest.
 	displayName := googleDisplayName(info)

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -18,6 +18,7 @@ func (s *mserver) routes() {
 
 	s.r.HandleFunc(s.prefixPath+"/auth/callback", s.handleGoogleCallback)
 	s.r.HandleFunc(s.prefixPath+"/auth/login/callback", s.handleGoogleLoginCallback)
+	s.r.HandleFunc(s.prefixPath+"/auth/guest/callback", s.handleGuestGoogleCallback)
 	s.mGET("/auth/method", s.mResponse(s.handleAuthMethod))
 
 	s.mGET("/cameras", s.loginInfo(s.handleCameras))
@@ -86,6 +87,7 @@ func (s *mserver) routes() {
 	s.mGET("/guest/verify", s.mResponse(s.handleVerifyGuest))
 	s.mPUT("/guest/login", s.mResponse(s.handleGuestLogin))
 	s.mPUT("/guest/login/verify", s.mResponse(s.handleGuestLoginVerify))
+	s.mGET("/guest/login/google", s.handleGuestGoogleRedirect)
 	s.mPUT("/likes/{photoid}/like", s.guestOnly(s.handleLikePhoto))
 	s.mPUT("/likes/{photoid}/unlike", s.guestOnly(s.handleUnlikePhoto))
 	s.mGET("/likes/{photoid}", s.loginInfo(s.handlePhotoLikes))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -20,18 +20,19 @@ import (
 )
 
 type mserver struct {
-	pg           *dao.PGDB
-	ds           *gdrive.DriveService
-	ms           *gmail.GmailService
-	r            *http.ServeMux
-	l            *zap.SugaredLogger
-	prefixPath   string
-	store        *sessions.CookieStore
-	cookieName   string
-	guestCookie  string
-	tokenFile    string
-	gconfig      *oauth2.Config
-	gconfigLogin *oauth2.Config
+	pg                *dao.PGDB
+	ds                *gdrive.DriveService
+	ms                *gmail.GmailService
+	r                 *http.ServeMux
+	l                 *zap.SugaredLogger
+	prefixPath        string
+	store             *sessions.CookieStore
+	cookieName        string
+	guestCookie       string
+	tokenFile         string
+	gconfig           *oauth2.Config
+	gconfigLogin      *oauth2.Config
+	gconfigGuestLogin *oauth2.Config
 }
 
 func newServer(prefixPath string, logger *zap.SugaredLogger) *mserver {
@@ -105,6 +106,16 @@ func newServer(prefixPath string, logger *zap.SugaredLogger) *mserver {
 		ClientSecret: config.GoogleClientSecret(),
 		Endpoint:     google.Endpoint,
 		RedirectURL:  config.AuthGoogleLoginRedirectUrl(),
+		Scopes:       []string{"openid", "email", "profile"},
+	}
+
+	// Guest Google login reuses the same OAuth client and minimal scopes as the
+	// owner login, but a distinct callback URL so the server knows it's a guest.
+	s.gconfigGuestLogin = &oauth2.Config{
+		ClientID:     config.GoogleClientId(),
+		ClientSecret: config.GoogleClientSecret(),
+		Endpoint:     google.Endpoint,
+		RedirectURL:  config.GuestGoogleRedirectUrl(),
 		Scopes:       []string{"openid", "email", "profile"},
 	}
 


### PR DESCRIPTION
Second guest-enrichment feature. **Stacked on #41 (avatar upload)** — it reuses the avatar URL-import to pull the Google profile picture. Base this PR's merge on #41; review its own diff against `feat/guest-avatar`.

## What

Guests can **sign in with Google** alongside the email one-time-code flow ("choose email code or Google"). We pull name/email/picture from Google.

## Identity resolution (the crux)

The callback resolves a verified Google profile to a guest, non-interactively (a redirect can't re-prompt):
1. **Linked by Google id** → log in to that guest.
2. **Same verified email as an existing guest** → **link** the Google id to that existing account (and verify it if it was still pending). So a guest who previously used the email code now has *one account, two ways in* — email code or Google, interchangeably. All their profile/comments/likes are preserved.
3. **New** → create a guest: nickname = Google display name (**auto-deduped** `-2/-3…` against the unique-name constraint), `fullName` = display name, verified, and **import the Google picture as their avatar** (best-effort, via #41's SSRF-guarded fetch + resize).

Note: picture import happens only on **new-guest creation** — linking an existing account never clobbers (nor fills) its avatar.

## Reuse + scope

- Mirrors the owner Google OAuth flow (`generateOAuthState`, single-use state cookie expired on first use, `redirTo` with `?error=`). A third OAuth config `gconfigGuestLogin` reuses the same client id/secret and minimal `openid/email/profile` scopes, with a distinct callback URL. **No email allowlist** — any verified Google account may be a guest.
- Extended `fetchGoogleUserinfo` to also return name/picture/sub (owner flow only read email/verified); owner callback updated accordingly.

## Migration (v7, appended)

`schemaV6toV7` adds `guest.googleid` + a **partial unique index** (`WHERE googleid <> ''`) — unique among linked guests, unrestricted for the empty default. `guest.GoogleId` is `json:"-"` (never exposed). Appended as `7: upgradeToV7`; the migration test now walks the full **v4→v5→v6→v7**.

## Config

New `auth.google.guestRedirectUrl` (added to `config_example.yaml`, asserted in `config_test.go`).

## Deploy / console prerequisites (can't verify from here)

- Register the guest callback (`…/api/auth/guest/callback`) as an authorized redirect URI in the Google console.
- The OAuth consent screen must be **Published** (not Testing) for arbitrary guests to sign in. Guest scopes are non-sensitive (`email`/`profile`), so no Google verification review is needed — but publishing is.

## Endpoints

- `GET /api/guest/login/google` → redirect to Google.
- `GET /api/auth/guest/callback` → callback (raw handler, redirects to the UI with `?error=` on failure).

## Testing

`make ci` green. New DAO test for googleid link/resolve + the unique-index enforcement; the migration walk now covers v4→v7.