### PR TITLE
Expose guest id and original photo format to clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ in the `mphotos-svelte` / `mphotos-ui` frontends.
 
 ## [Unreleased]
 
+### Added
+
+- `GET /api/guest` (plus the guest login/verify and avatar-mutation responses) now
+  includes the guest's own id as `guestId`, so a logged-in guest can build their own
+  avatar URL `/api/guest/avatar/{guestId}` — the same field name reactions and comments
+  already use.
+  - **Frontend impact:** the guest profile page and edit dialog can now show and manage
+    the guest's *own* avatar (others' already worked via `guestId` in likes/comments).
+- Photo responses now include `sourceOther`, the original image format (`tiff`, `png`, …),
+  omitted when empty (photos imported before conversion tracking).
+  - **Frontend impact:** optional — enables a "converted from TIFF/PNG/…" badge.
+
 ## [0.4.0] - 2026-08-07
 
 ### Added

--- a/internal/dao/types.go
+++ b/internal/dao/types.go
@@ -69,7 +69,7 @@ type Exif struct {
 }
 
 type Guest struct {
-	Id          uuid.UUID `json:"-"`
+	Id          uuid.UUID `json:"guestId"`
 	Email       string    `json:"email"`
 	Name        string    `json:"name"`
 	FullName    string    `json:"fullName"`
@@ -83,7 +83,7 @@ type Guest struct {
 // GuestReaction is the public view of a reaction. It deliberately carries no
 // email: it is serialized by the unauthenticated GET /likes/{photoid} route.
 // The guest id + avatar let the frontend render the guest's avatar
-// (GET /guest/{guestId}/avatar); the id is not a secret (auth is the signed
+// (GET /guest/avatar/{guestId}); the id is not a secret (auth is the signed
 // cookie), and fullName/email are never exposed here.
 type GuestReaction struct {
 	Id          uuid.UUID `json:"guestId"`
@@ -98,7 +98,7 @@ type Photo struct {
 	Md5          string    `json:"md5"`
 	Source       string    `json:"source"`
 	SourceId     string    `json:"-"`
-	SourceOther  string    `json:"-"`
+	SourceOther  string    `json:"sourceOther,omitempty"`
 	SourceDate   time.Time `json:"sourceDate"`
 	UploadDate   time.Time `json:"uploadDate"`
 	OriginalDate time.Time `json:"originalDate"`

--- a/internal/dao/types_test.go
+++ b/internal/dao/types_test.go
@@ -1,0 +1,62 @@
+package dao
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// TestGuestJSONExposesGuestId guards the fix that lets a logged-in guest build
+// their own avatar URL (GET /api/guest/avatar/{guestId}): the Guest record must
+// serialize its id as "guestId", matching the name reactions/comments already
+// use. It also pins that the internal googleId stays hidden. Pure marshal, no DB.
+func TestGuestJSONExposesGuestId(t *testing.T) {
+	id := uuid.New()
+	b, err := json.Marshal(Guest{Id: id, Email: "g@example.com", GoogleId: "secret"})
+	if err != nil {
+		t.Fatalf("marshal Guest: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m["guestId"] != id.String() {
+		t.Errorf("guestId = %v, want %s", m["guestId"], id)
+	}
+	if _, ok := m["email"]; !ok {
+		t.Error("email should be present in the guest's own record")
+	}
+	if _, ok := m["googleId"]; ok {
+		t.Error("googleId must never be serialized")
+	}
+}
+
+// TestPhotoSourceOtherJSON: the original image format is exposed as "sourceOther"
+// when set and omitted when empty (photos imported before conversion tracking).
+// The internal sourceId stays hidden.
+func TestPhotoSourceOtherJSON(t *testing.T) {
+	b, err := json.Marshal(Photo{SourceOther: "tiff", SourceId: "drive-123"})
+	if err != nil {
+		t.Fatalf("marshal Photo: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m["sourceOther"] != "tiff" {
+		t.Errorf("sourceOther = %v, want tiff", m["sourceOther"])
+	}
+	if _, ok := m["sourceId"]; ok {
+		t.Error("sourceId must never be serialized")
+	}
+
+	b, _ = json.Marshal(Photo{})
+	m = map[string]any{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal empty: %v", err)
+	}
+	if _, ok := m["sourceOther"]; ok {
+		t.Error("empty sourceOther should be omitted (omitempty)")
+	}
+}


### PR DESCRIPTION
Two additive API-field changes so the frontend can finish the guest-avatar work, from a bug report while dogfooding v0.4.0.

## Problem 1 (blocker): a guest can't get their own avatar URL
Avatars are served by UUID (`GET /api/guest/avatar/{guestid}`), but `Guest.Id` was `json:"-"`, so `GET /api/guest` (and login/verify + the avatar-mutation responses) returned the guest's profile **without** an id. Others' avatars already render because likes/comments carry `guestId`; a guest just couldn't build their **own** URL.

**Fix:** serialize `Guest.Id` as `guestId` — the same field name reactions/comments already use. The id is not a secret (auth is the signed cookie, and it's already public in likes), and the full `Guest` struct only serializes to the guest themselves or the owner, so no new email/id leak.

## Problem 2 (optional): original format not exposed
`Photo.SourceOther` records the original format (`tiff`, `png`, …) but was `json:"-"`. Now serialized as `sourceOther` (`omitempty`, so pre-conversion photos omit it), enabling a "converted from TIFF/PNG/…" badge if wanted.

## Also
- Fixed a stale doc comment on `GuestReaction` that still referenced the pre-v0.4.0 `/guest/{guestId}/avatar` route.

## Testing
- `make ci` green.
- New `internal/dao/types_test.go` — DB-free marshal guards: `guestId`/`email` present and `googleId` hidden; `sourceOther` present when set / omitted when empty and `sourceId` hidden. These pin the fix against a silent revert to `json:"-"`.

## Frontend impact
- Guest profile page / edit dialog can now show and manage the guest's own avatar.
- Optional original-format badge on photos.