### PR TITLE
Guard server startup against a mismatched DB schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ in the `mphotos-svelte` / `mphotos-ui` frontends.
 
 ## [Unreleased]
 
+### Changed
+
+- The server now verifies the database schema version at startup and refuses to
+  start — with a clear message — when the database is behind or ahead of the
+  binary, instead of failing later at runtime on a missing column. Upgrading
+  remains a deliberate, separate `db upgrade` step (the server never auto-migrates).
+
 ## [0.5.0] - 2026-08-07
 
 ### Added

--- a/internal/dao/dao.go
+++ b/internal/dao/dao.go
@@ -122,6 +122,7 @@ type VersionDAO interface {
 	Update() (*Version, error)
 	Set(versionId int) (*Version, error)
 	IsCurrent() (bool, error)
+	Check() error
 }
 
 type PGDB struct {

--- a/internal/dao/version.go
+++ b/internal/dao/version.go
@@ -55,3 +55,23 @@ func (dao *VersionPG) IsCurrent() (bool, error) {
 		return v.VersionId == DbVersion, nil
 	}
 }
+
+// Check verifies the database schema matches the binary's DbVersion, returning a
+// descriptive error (it never mutates) when the database is behind, ahead, or
+// unreadable. The server calls this at startup to refuse a mismatched schema up
+// front instead of failing at runtime on a missing column. It does not upgrade —
+// migrations stay a deliberate, separate `db upgrade` step.
+func (dao *VersionPG) Check() error {
+	v, err := dao.Get()
+	if err != nil {
+		return fmt.Errorf("could not read database version (is the database initialized? run `db create` / `db upgrade`): %w", err)
+	}
+	switch {
+	case v.VersionId == DbVersion:
+		return nil
+	case v.VersionId < DbVersion:
+		return fmt.Errorf("database schema is at version %d but this binary requires %d; run `db upgrade` before starting the server", v.VersionId, DbVersion)
+	default:
+		return fmt.Errorf("database schema is at version %d, newer than this binary (%d); deploy the matching build", v.VersionId, DbVersion)
+	}
+}

--- a/internal/dao/version_test.go
+++ b/internal/dao/version_test.go
@@ -1,0 +1,45 @@
+package dao
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestVersionCheck covers the startup guard: a current database passes, a behind
+// database fails with a message pointing at `db upgrade`, and a database newer
+// than the binary also fails. Guards against the silent runtime failure a
+// schema-behind server produced (a missing column only blew up mid-request).
+func TestVersionCheck(t *testing.T) {
+	pgdb := openAndCreateTestDb(t)
+	defer deleteAndCloseTestDb(pgdb, t)
+
+	// A freshly created db is stamped at DbVersion, so Check passes.
+	if err := pgdb.Version.Check(); err != nil {
+		t.Fatalf("Check should pass on a current db, got: %v", err)
+	}
+
+	// Behind the binary -> error that tells the operator to upgrade.
+	if _, err := pgdb.Version.Set(DbVersion - 1); err != nil {
+		t.Fatalf("could not set version behind: %v", err)
+	}
+	err := pgdb.Version.Check()
+	if err == nil {
+		t.Fatal("Check should fail when the db is behind the binary")
+	}
+	if !strings.Contains(err.Error(), "db upgrade") {
+		t.Errorf("behind error should point to `db upgrade`, got: %v", err)
+	}
+
+	// Newer than the binary -> error (an old binary must not run a newer schema).
+	if _, err := pgdb.Version.Set(DbVersion + 1); err != nil {
+		t.Fatalf("could not set version ahead: %v", err)
+	}
+	if err := pgdb.Version.Check(); err == nil {
+		t.Error("Check should fail when the db is newer than the binary")
+	}
+
+	// Restore the marker so teardown leaves a consistent db.
+	if _, err := pgdb.Version.Set(DbVersion); err != nil {
+		t.Fatalf("could not restore version: %v", err)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -140,6 +140,14 @@ func StartMServer() {
 	}
 
 	s := newServer("/api", l.Sugar())
+
+	// Refuse to start against a mismatched schema: a behind or ahead database fails
+	// here with a clear message instead of silently breaking at runtime. Upgrading
+	// stays a deliberate, separate `db upgrade` step.
+	if err := s.pg.Version.Check(); err != nil {
+		s.l.Fatalw("database schema check failed", zap.Error(err))
+	}
+
 	s.routes()
 
 	//auth


### PR DESCRIPTION
## Why
While testing guest avatars, an upload "failed" in the UI but wrote its files to disk. Root cause: the dev DB was stuck at schema **v5** (missing the `guest.avatar` column added in v6), so the handler wrote files then died on `UPDATE guest SET avatar=…`. The server had started happily against a behind schema and only broke mid-request — a confusing, silent failure.

This adds a startup guard so a mismatched schema fails **at boot with a clear message** instead.

## What
- `VersionDAO.Check()` (`internal/dao/version.go`): compares the stamped schema version to the binary's `DbVersion` and returns a directional error — behind → "run `db upgrade` before starting the server"; ahead → "newer than this binary; deploy the matching build"; unreadable → "is the database initialized?". It **never mutates**.
- `StartMServer` calls it right after connecting the DB and before serving; on error it `Fatalw`s, so the server refuses to boot.

## Design notes
- **No auto-migration.** Upgrading stays a deliberate, separate `db upgrade` step — the server only checks. (Auto-upgrade on startup was considered and rejected: it would silently mutate prod on deploy.)
- **Self-maintaining.** `Check()` reads the `DbVersion` constant, so adding a migration + bumping the constant automatically updates what the guard expects — no per-migration bookkeeping.
- **Doesn't block the fix.** The `db` cobra commands don't go through `StartMServer`, so a behind DB can still run `db upgrade`.

## Testing
- `make ci` green.
- New `TestVersionCheck` (`internal/dao/version_test.go`): current passes; behind fails and points at `db upgrade`; ahead fails.