### PR TITLE
Give db CLI commands proper exit codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ in the `mphotos-svelte` / `mphotos-ui` frontends.
 
 ## [Unreleased]
 
+### Added
+
+- `db check` CLI subcommand — a read-only gate that exits non-zero (with a
+  message) when the database schema doesn't match the binary. Intended for a
+  deploy script to run before starting the server, which otherwise hard-stops
+  and crash-loops on a mismatch while `systemctl start` reports success.
+
+### Fixed
+
+- `db upgrade` now exits non-zero when a migration fails (it previously printed
+  the error but exited 0, hiding failures from deploy scripts).
+
 ## [0.6.0] - 2026-08-19
 
 ### Added

--- a/cmd/checkdb.go
+++ b/cmd/checkdb.go
@@ -1,0 +1,55 @@
+/*
+Copyright © 2020 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/msvens/mphotos/internal/config"
+	"github.com/msvens/mphotos/internal/dao"
+	"github.com/spf13/cobra"
+)
+
+// checkCmd verifies the database schema matches this binary's DbVersion. It is the
+// machine-checkable counterpart to `db version`: it exits non-zero (with a
+// message) when the DB is behind or ahead, so a deploy script can gate on it
+// before starting the server — which would otherwise hard-stop and crash-loop
+// while systemctl still reported success. Read-only.
+var checkCmd = &cobra.Command{
+	Use:           "check",
+	Short:         "Verify the database schema matches this binary (exit non-zero on mismatch)",
+	Long:          `Checks that the database schema version equals the version this binary targets. Read-only; exits non-zero with a message if a migration is needed or the database is newer than the binary. Intended as a pre-start gate in deploy scripts.`,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := config.InitConfig(); err != nil {
+			return err
+		}
+		db, err := dao.NewPGDB()
+		if err != nil {
+			return err
+		}
+		if err := db.Version.Check(); err != nil {
+			return err
+		}
+		fmt.Printf("Database schema is up to date (version %d).\n", dao.DbVersion)
+		return nil
+	},
+}
+
+func init() {
+	dbCmd.AddCommand(checkCmd)
+}

--- a/cmd/upgradedb.go
+++ b/cmd/upgradedb.go
@@ -26,14 +26,15 @@ var upgradedbCmd = &cobra.Command{
 	Use:   "upgrade",
 	Short: "Upgrade mphotos database",
 	Long:  `Upgrades the mphotos database to the latest version if possible`,
-	Run: func(cmd *cobra.Command, args []string) {
+	// RunE so a failed migration exits non-zero (UpgradeDb is a no-op, exit 0, when
+	// already current). Silence cobra's error/usage dump; Execute() prints the error.
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := config.InitConfig(); err != nil {
-			println(err.Error())
-			return
+			return err
 		}
-		if err := dao.UpgradeDb(); err != nil {
-			println(err.Error())
-		}
+		return dao.UpgradeDb()
 	},
 }
 


### PR DESCRIPTION
## Why
The startup guard (v0.5.1) hard-stops the *server* on a schema mismatch, but a deploy runs `systemctl start`, which returns success **before** that check fails — so the service crash-loops while the deploy reports success. The `db` CLI can't help either: both subcommands use cobra's `Run` and always exit 0, printing errors to stdout. So a broken migration or a mismatch is invisible to a deploy script.

## Changes
- **`cmd/upgradedb.go`** — `Run` → `RunE`, returns the error so a failed migration exits non-zero. `UpgradeDb()` returns nil when the DB is already current, so running it every deploy still exits 0.
- **`cmd/checkdb.go`** (new) — `db check`: a read-only gate that runs `Version.Check()` and exits non-zero with a message when the DB is behind or ahead of the binary; prints a confirmation and exits 0 when current. This is the machine-checkable counterpart to the human-readable `db version` (which stays as-is).
- Both `RunE` commands set `SilenceUsage`/`SilenceErrors` so failures print a single clean line (the existing `Execute()` already writes the error to stderr and `os.Exit(1)`s) instead of cobra's doubled error + usage dump.

## Testing
- `make ci` green.
- Verified live: `db check` against a current (v8) DB prints `Database schema is up to date (version 8).` and exits 0. The mismatch path returns `Version.Check()`'s descriptive error → non-zero exit (covered by `TestVersionCheck` + the `Execute()` `os.Exit(1)` wiring).

## Deploy usage
```sh
./mphotos db upgrade   # aborts the deploy if a migration fails
./mphotos db check     # pre-start gate: non-zero if a migration is still needed / DB newer than binary
```

No HTTP API change — CLI/ops only. Suggested release: **v0.6.1** (patch).