### PR TITLE
Fix /api/cameras 500 on NULL camera columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ in the `mphotos-svelte` / `mphotos-ui` frontends.
 
 ## [Unreleased]
 
+### Fixed
+
+- `GET /api/cameras` no longer fails (500 in the envelope) when a camera row has
+  NULL columns. Every camera column is now non-null with a default, and a v9
+  migration backfills existing NULLs. Previously a single NULL (e.g. `year`)
+  aborted the row scan and took out the whole list.
+
 ## [0.6.1] - 2026-08-20
 
 ### Added

--- a/internal/dao/dao.go
+++ b/internal/dao/dao.go
@@ -196,7 +196,7 @@ func (pgd *PGDB) tableExists(table string) bool {
 }
 
 func (pgd *PGDB) CreateTables() error {
-	if _, err := pgd.db.Exec(schemaV8); err != nil {
+	if _, err := pgd.db.Exec(schemaV9); err != nil {
 		return err
 	} else { //make sure version is correct
 		_, err = pgd.Version.Update()
@@ -208,6 +208,6 @@ func (pgd *PGDB) CreateTables() error {
 }
 
 func (pgd *PGDB) DeleteTables() error {
-	_, err := pgd.db.Exec(deleteSchemaV8)
+	_, err := pgd.db.Exec(deleteSchemaV9)
 	return err
 }

--- a/internal/dao/migrate.go
+++ b/internal/dao/migrate.go
@@ -17,6 +17,7 @@ var migrations = map[int]func(*PGDB) error{
 	6: upgradeToV6,
 	7: upgradeToV7,
 	8: upgradeToV8,
+	9: upgradeToV9,
 }
 
 // UpgradeDb brings the database up to the binary's DbVersion, applying each
@@ -105,5 +106,13 @@ func upgradeToV7(pgdb *PGDB) error {
 // the "No Camera" sentinel.
 func upgradeToV8(pgdb *PGDB) error {
 	_, err := pgdb.db.Exec(schemaV7toV8)
+	return err
+}
+
+// upgradeToV9 takes a v8 database to v9, backfilling NULL camera columns and
+// pinning them NOT NULL DEFAULT so a partially-filled camera can't crash the
+// /api/cameras row scan.
+func upgradeToV9(pgdb *PGDB) error {
+	_, err := pgdb.db.Exec(schemaV8toV9)
 	return err
 }

--- a/internal/dao/migrate_test.go
+++ b/internal/dao/migrate_test.go
@@ -131,6 +131,62 @@ func TestUpgradeToV8NoCamera(t *testing.T) {
 	}
 }
 
+// TestUpgradeToV9CameraNulls: the v8->v9 step backfills NULL camera columns and
+// pins them NOT NULL, so a partially-filled camera no longer aborts the whole
+// /api/cameras row scan. Rewinds a few representative columns to the nullable
+// pre-v9 shape, inserts a camera with NULLs, and asserts the list scan goes from
+// failing to succeeding with the NULLs backfilled to zero values.
+func TestUpgradeToV9CameraNulls(t *testing.T) {
+	pgdb := openAndCreateTestDb(t)
+	defer deleteAndCloseTestDb(pgdb, t)
+
+	// Rewind an int/real/bool/text column to nullable-without-default (the v8 shape).
+	for _, stmt := range []string{
+		"ALTER TABLE camera ALTER COLUMN year DROP NOT NULL, ALTER COLUMN year DROP DEFAULT",
+		"ALTER TABLE camera ALTER COLUMN cropFactor DROP NOT NULL, ALTER COLUMN cropFactor DROP DEFAULT",
+		"ALTER TABLE camera ALTER COLUMN gps DROP NOT NULL, ALTER COLUMN gps DROP DEFAULT",
+		"ALTER TABLE camera ALTER COLUMN sensorSize DROP NOT NULL, ALTER COLUMN sensorSize DROP DEFAULT",
+	} {
+		if _, err := pgdb.db.Exec(stmt); err != nil {
+			t.Fatalf("rewind %q: %v", stmt, err)
+		}
+	}
+	if _, err := pgdb.db.Exec(
+		"INSERT INTO camera (id, model, make, year, cropFactor, gps, sensorSize) VALUES ('nulcam','M','Mk',NULL,NULL,NULL,NULL)"); err != nil {
+		t.Fatalf("insert null camera: %v", err)
+	}
+	if _, err := pgdb.db.Exec("UPDATE version SET versionId = 8"); err != nil {
+		t.Fatalf("set version 8: %v", err)
+	}
+
+	// The bug: a NULL column aborts the whole list scan before the migration.
+	if _, err := pgdb.Camera.List(); err == nil {
+		t.Fatal("expected Camera.List to fail on a NULL camera column pre-migration")
+	}
+
+	if err := UpgradeDb(); err != nil {
+		t.Fatalf("UpgradeDb failed: %v", err)
+	}
+
+	// After: the list scans cleanly and the NULLs are backfilled to zero values.
+	cams, err := pgdb.Camera.List()
+	if err != nil {
+		t.Fatalf("Camera.List should succeed after v9, got: %v", err)
+	}
+	var c *Camera
+	for _, cam := range cams {
+		if cam.Id == "nulcam" {
+			c = cam
+		}
+	}
+	if c == nil {
+		t.Fatal("camera row missing after migration")
+	}
+	if c.Year != 0 || c.CropFactor != 0 || c.Gps || c.SensorSize != "" {
+		t.Errorf("NULLs not backfilled to zero values: %+v", c)
+	}
+}
+
 // TestUpgradeNewerThanBinary: a database ahead of the binary must error, not
 // silently proceed.
 func TestUpgradeNewerThanBinary(t *testing.T) {

--- a/internal/dao/schema.go
+++ b/internal/dao/schema.go
@@ -36,7 +36,81 @@ const schemaV7toV8 = `
 	DELETE FROM camera WHERE id = '';
 	INSERT INTO camera (id, model, make) VALUES ('no-camera', 'No Camera', '') ON CONFLICT (id) DO NOTHING;
 `
-const schemaV8 = `
+
+// schemaV8toV9 makes every nullable camera column non-null. A single NULL in any
+// of them aborted the row scan for the whole /api/cameras list, because the Go
+// Camera struct scans them into non-pointer int/float/bool/string. Backfill
+// existing NULLs to the type's zero value, then pin NOT NULL DEFAULT so new rows
+// can't reintroduce them (e.g. the v8 'no-camera' sentinel, which was inserted
+// with only id/model/make and left the rest NULL). Idempotent.
+const schemaV8toV9 = `
+UPDATE camera SET
+	year = COALESCE(year, 0),
+	effectivePixels = COALESCE(effectivePixels, 0),
+	totalPixels = COALESCE(totalPixels, 0),
+	sensorSize = COALESCE(sensorSize, ''),
+	sensorType = COALESCE(sensorType, ''),
+	sensorResolution = COALESCE(sensorResolution, ''),
+	imageResolution = COALESCE(imageResolution, ''),
+	cropFactor = COALESCE(cropFactor, 0),
+	opticalZoom = COALESCE(opticalZoom, 0),
+	digitalZoom = COALESCE(digitalZoom, FALSE),
+	iso = COALESCE(iso, ''),
+	raw = COALESCE(raw, FALSE),
+	manualFocus = COALESCE(manualFocus, FALSE),
+	focusRange = COALESCE(focusRange, 0),
+	macroFocusRange = COALESCE(macroFocusRange, 0),
+	focalLengthEquiv = COALESCE(focalLengthEquiv, ''),
+	aperturePriority = COALESCE(aperturePriority, FALSE),
+	maxAperture = COALESCE(maxAperture, ''),
+	maxApertureEquiv = COALESCE(maxApertureEquiv, ''),
+	metering = COALESCE(metering, ''),
+	exposureComp = COALESCE(exposureComp, ''),
+	shutterPriority = COALESCE(shutterPriority, FALSE),
+	minShutterSpeed = COALESCE(minShutterSpeed, ''),
+	maxShutterSpeed = COALESCE(maxShutterSpeed, ''),
+	builtInFlash = COALESCE(builtInFlash, FALSE),
+	externalFlash = COALESCE(externalFlash, FALSE),
+	viewFinder = COALESCE(viewFinder, ''),
+	videoCapture = COALESCE(videoCapture, FALSE),
+	maxVideoResolution = COALESCE(maxVideoResolution, ''),
+	gps = COALESCE(gps, FALSE),
+	image = COALESCE(image, '');
+
+ALTER TABLE camera
+	ALTER COLUMN year SET DEFAULT 0, ALTER COLUMN year SET NOT NULL,
+	ALTER COLUMN effectivePixels SET DEFAULT 0, ALTER COLUMN effectivePixels SET NOT NULL,
+	ALTER COLUMN totalPixels SET DEFAULT 0, ALTER COLUMN totalPixels SET NOT NULL,
+	ALTER COLUMN sensorSize SET DEFAULT '', ALTER COLUMN sensorSize SET NOT NULL,
+	ALTER COLUMN sensorType SET DEFAULT '', ALTER COLUMN sensorType SET NOT NULL,
+	ALTER COLUMN sensorResolution SET DEFAULT '', ALTER COLUMN sensorResolution SET NOT NULL,
+	ALTER COLUMN imageResolution SET DEFAULT '', ALTER COLUMN imageResolution SET NOT NULL,
+	ALTER COLUMN cropFactor SET DEFAULT 0, ALTER COLUMN cropFactor SET NOT NULL,
+	ALTER COLUMN opticalZoom SET DEFAULT 0, ALTER COLUMN opticalZoom SET NOT NULL,
+	ALTER COLUMN digitalZoom SET DEFAULT FALSE, ALTER COLUMN digitalZoom SET NOT NULL,
+	ALTER COLUMN iso SET DEFAULT '', ALTER COLUMN iso SET NOT NULL,
+	ALTER COLUMN raw SET DEFAULT FALSE, ALTER COLUMN raw SET NOT NULL,
+	ALTER COLUMN manualFocus SET DEFAULT FALSE, ALTER COLUMN manualFocus SET NOT NULL,
+	ALTER COLUMN focusRange SET DEFAULT 0, ALTER COLUMN focusRange SET NOT NULL,
+	ALTER COLUMN macroFocusRange SET DEFAULT 0, ALTER COLUMN macroFocusRange SET NOT NULL,
+	ALTER COLUMN focalLengthEquiv SET DEFAULT '', ALTER COLUMN focalLengthEquiv SET NOT NULL,
+	ALTER COLUMN aperturePriority SET DEFAULT FALSE, ALTER COLUMN aperturePriority SET NOT NULL,
+	ALTER COLUMN maxAperture SET DEFAULT '', ALTER COLUMN maxAperture SET NOT NULL,
+	ALTER COLUMN maxApertureEquiv SET DEFAULT '', ALTER COLUMN maxApertureEquiv SET NOT NULL,
+	ALTER COLUMN metering SET DEFAULT '', ALTER COLUMN metering SET NOT NULL,
+	ALTER COLUMN exposureComp SET DEFAULT '', ALTER COLUMN exposureComp SET NOT NULL,
+	ALTER COLUMN shutterPriority SET DEFAULT FALSE, ALTER COLUMN shutterPriority SET NOT NULL,
+	ALTER COLUMN minShutterSpeed SET DEFAULT '', ALTER COLUMN minShutterSpeed SET NOT NULL,
+	ALTER COLUMN maxShutterSpeed SET DEFAULT '', ALTER COLUMN maxShutterSpeed SET NOT NULL,
+	ALTER COLUMN builtInFlash SET DEFAULT FALSE, ALTER COLUMN builtInFlash SET NOT NULL,
+	ALTER COLUMN externalFlash SET DEFAULT FALSE, ALTER COLUMN externalFlash SET NOT NULL,
+	ALTER COLUMN viewFinder SET DEFAULT '', ALTER COLUMN viewFinder SET NOT NULL,
+	ALTER COLUMN videoCapture SET DEFAULT FALSE, ALTER COLUMN videoCapture SET NOT NULL,
+	ALTER COLUMN maxVideoResolution SET DEFAULT '', ALTER COLUMN maxVideoResolution SET NOT NULL,
+	ALTER COLUMN gps SET DEFAULT FALSE, ALTER COLUMN gps SET NOT NULL,
+	ALTER COLUMN image SET DEFAULT '', ALTER COLUMN image SET NOT NULL;
+`
+const schemaV9 = `
 CREATE TABLE IF NOT EXISTS album (
 	Id UUID,
 	name TEXT,
@@ -58,37 +132,37 @@ CREATE TABLE IF NOT EXISTS camera (
     id TEXT PRIMARY KEY,
     model TEXT NOT NULL,
 	make TEXT NOT NULL,
-	year INTEGER,
-	effectivePixels INTEGER,
-	totalPixels INTEGER,
-	sensorSize TEXT,
-	sensorType TEXT,
-	sensorResolution TEXT,
-	imageResolution TEXT,
-	cropFactor REAL,
-	opticalZoom REAL,
-	digitalZoom BOOLEAN,
-	iso TEXT,
-	raw BOOLEAN,
-	manualFocus BOOLEAN,
-	focusRange INTEGER,
-	macroFocusRange INTEGER,
-	focalLengthEquiv TEXT,
-	aperturePriority BOOLEAN,
-	maxAperture TEXT,
-	maxApertureEquiv TEXT,
-	metering TEXT,
-	exposureComp TEXT,
-	shutterPriority BOOLEAN,
-	minShutterSpeed TEXT,
-	maxShutterSpeed TEXT,
-	builtInFlash BOOLEAN,
-	externalFlash BOOLEAN,
-	viewFinder TEXT,
-	videoCapture BOOLEAN,
-	maxVideoResolution TEXT,
-	gps BOOLEAN,
-	image TEXT
+	year INTEGER NOT NULL DEFAULT 0,
+	effectivePixels INTEGER NOT NULL DEFAULT 0,
+	totalPixels INTEGER NOT NULL DEFAULT 0,
+	sensorSize TEXT NOT NULL DEFAULT '',
+	sensorType TEXT NOT NULL DEFAULT '',
+	sensorResolution TEXT NOT NULL DEFAULT '',
+	imageResolution TEXT NOT NULL DEFAULT '',
+	cropFactor REAL NOT NULL DEFAULT 0,
+	opticalZoom REAL NOT NULL DEFAULT 0,
+	digitalZoom BOOLEAN NOT NULL DEFAULT FALSE,
+	iso TEXT NOT NULL DEFAULT '',
+	raw BOOLEAN NOT NULL DEFAULT FALSE,
+	manualFocus BOOLEAN NOT NULL DEFAULT FALSE,
+	focusRange INTEGER NOT NULL DEFAULT 0,
+	macroFocusRange INTEGER NOT NULL DEFAULT 0,
+	focalLengthEquiv TEXT NOT NULL DEFAULT '',
+	aperturePriority BOOLEAN NOT NULL DEFAULT FALSE,
+	maxAperture TEXT NOT NULL DEFAULT '',
+	maxApertureEquiv TEXT NOT NULL DEFAULT '',
+	metering TEXT NOT NULL DEFAULT '',
+	exposureComp TEXT NOT NULL DEFAULT '',
+	shutterPriority BOOLEAN NOT NULL DEFAULT FALSE,
+	minShutterSpeed TEXT NOT NULL DEFAULT '',
+	maxShutterSpeed TEXT NOT NULL DEFAULT '',
+	builtInFlash BOOLEAN NOT NULL DEFAULT FALSE,
+	externalFlash BOOLEAN NOT NULL DEFAULT FALSE,
+	viewFinder TEXT NOT NULL DEFAULT '',
+	videoCapture BOOLEAN NOT NULL DEFAULT FALSE,
+	maxVideoResolution TEXT NOT NULL DEFAULT '',
+	gps BOOLEAN NOT NULL DEFAULT FALSE,
+	image TEXT NOT NULL DEFAULT ''
 );
 
 CREATE INDEX IF NOT EXISTS model_idx ON camera (model);
@@ -188,7 +262,7 @@ INSERT INTO version (versionId,description) VALUES (0,'no version set') ON CONFL
 INSERT INTO usert (id, name, bio, pic, driveFolderId, driveFolderName, config) VALUES (23657, '', '', '', '','','{}') ON CONFLICT (id) DO NOTHING;
 `
 
-const deleteSchemaV8 = `
+const deleteSchemaV9 = `
 DROP TABLE IF EXISTS album;
 DROP TABLE IF EXISTS albumphotos;
 DROP TABLE IF EXISTS camera;

--- a/internal/dao/types.go
+++ b/internal/dao/types.go
@@ -6,8 +6,8 @@ import (
 	"time"
 )
 
-const DbVersion = 8
-const DbDescription = "Version 8 normalizes cameraless photos to the No Camera sentinel"
+const DbVersion = 9
+const DbDescription = "Version 9 makes all camera columns non-null with defaults"
 
 type Album struct {
 	Id          uuid.UUID  `json:"id"`


### PR DESCRIPTION
## Bug
`GET /api/cameras` returns a `500` error envelope (`sql: Scan error on column index 3, name "year": converting NULL to int is unsupported`) whenever any camera row has a NULL column. The svelte frontend renders this as "no cameras found". Found in prod (mellowtech.org); local worked only because the local data had no NULL-year row.

## Root cause
Every camera column except `id`/`model`/`make` is nullable in the schema but scanned into a **non-pointer** Go type (`int`/`float32`/`bool`/`string`). A single NULL aborts the whole row scan, failing the entire list endpoint. `year` was just the first NULL to surface in prod data — ~30 columns have the same mismatch (e.g. the v8 `no-camera` sentinel was inserted with only id/model/make).

## Fix (schema, option 1)
v8→v9 migration that makes the DB agree with the struct:
- Backfill existing NULLs to the type's zero value (`COALESCE`).
- Pin every camera column `NOT NULL DEFAULT` (0 / '' / FALSE), so new partial inserts can't reintroduce NULLs.
- Correct the base `CREATE TABLE camera` so fresh databases match.

Follows the standard migration recipe (`DbVersion` 8→9, `schemaV8toV9`, `schemaV9`/`deleteSchemaV9`, `9: upgradeToV9`).

## Not changed
The transport-200 `{error}` envelope is left as-is — it's the deliberate API convention (real status in `error.code`). The frontend treating an error envelope as an empty list is a separate frontend-side gap.

## Testing
- `make ci` green.
- `TestUpgradeToV9CameraNulls` reproduces the crash: `Camera.List()` **fails** on a NULL column before the migration and **succeeds** after, with the NULLs backfilled to zero values. The full v4→v9 upgrade walk also passes.

## Deploy note
`db upgrade` on deploy backfills every NULL camera column in prod automatically (not just `year`).